### PR TITLE
fix: warn to stderr when unknown --format value is provided (fixes #38)

### DIFF
--- a/.changeset/fix-unknown-format-warning.md
+++ b/.changeset/fix-unknown-format-warning.md
@@ -1,0 +1,5 @@
+---
+"gws": patch
+---
+
+fix: warn to stderr when unknown --format value is provided

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -35,13 +35,25 @@ pub enum OutputFormat {
 
 impl OutputFormat {
     /// Parse from a string argument.
-    pub fn from_str(s: &str) -> Self {
+    ///
+    /// Returns `Ok(format)` for known values, or `Err(unknown_value)` if the
+    /// string is not recognised.  Call sites should warn the user on `Err` and
+    /// decide whether to fall back to JSON or surface an error.
+    pub fn parse(s: &str) -> Result<Self, String> {
         match s.to_lowercase().as_str() {
-            "table" => Self::Table,
-            "yaml" | "yml" => Self::Yaml,
-            "csv" => Self::Csv,
-            _ => Self::Json,
+            "json" => Ok(Self::Json),
+            "table" => Ok(Self::Table),
+            "yaml" | "yml" => Ok(Self::Yaml),
+            "csv" => Ok(Self::Csv),
+            other => Err(other.to_string()),
         }
+    }
+
+    /// Parse from a string argument, falling back to JSON for unknown values.
+    ///
+    /// Prefer `parse()` at call sites where you want to surface a warning.
+    pub fn from_str(s: &str) -> Self {
+        Self::parse(s).unwrap_or(Self::Json)
     }
 }
 
@@ -369,6 +381,25 @@ mod tests {
         assert_eq!(OutputFormat::from_str("yml"), OutputFormat::Yaml);
         assert_eq!(OutputFormat::from_str("csv"), OutputFormat::Csv);
         assert_eq!(OutputFormat::from_str("unknown"), OutputFormat::Json);
+    }
+
+    #[test]
+    fn test_output_format_parse_known() {
+        assert_eq!(OutputFormat::parse("json"), Ok(OutputFormat::Json));
+        assert_eq!(OutputFormat::parse("table"), Ok(OutputFormat::Table));
+        assert_eq!(OutputFormat::parse("yaml"), Ok(OutputFormat::Yaml));
+        assert_eq!(OutputFormat::parse("yml"), Ok(OutputFormat::Yaml));
+        assert_eq!(OutputFormat::parse("csv"), Ok(OutputFormat::Csv));
+        // Case-insensitive
+        assert_eq!(OutputFormat::parse("JSON"), Ok(OutputFormat::Json));
+        assert_eq!(OutputFormat::parse("TABLE"), Ok(OutputFormat::Table));
+    }
+
+    #[test]
+    fn test_output_format_parse_unknown_returns_err() {
+        assert!(OutputFormat::parse("bogus").is_err());
+        assert_eq!(OutputFormat::parse("bogus").unwrap_err(), "bogus");
+        assert!(OutputFormat::parse("").is_err());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,10 +139,18 @@ async fn run() -> Result<(), GwsError> {
     })?;
 
     // Resolve --format flag
-    let output_format = matches
-        .get_one::<String>("format")
-        .map(|s| formatter::OutputFormat::from_str(s))
-        .unwrap_or_default();
+    let output_format = match matches.get_one::<String>("format") {
+        Some(s) => match formatter::OutputFormat::parse(s) {
+            Ok(fmt) => fmt,
+            Err(unknown) => {
+                eprintln!(
+                    "warning: unknown output format '{unknown}'; falling back to json (valid options: json, table, yaml, csv)"
+                );
+                formatter::OutputFormat::Json
+            }
+        },
+        None => formatter::OutputFormat::default(),
+    };
 
     // Resolve --sanitize template (flag or env var)
     let sanitize_template = matches


### PR DESCRIPTION
Fixes #38

## Changes
- Added `OutputFormat::parse(s) -> Result<Self, String>` which returns `Err` for unknown format strings
- Updated `main.rs` to call the new `parse()` method and print a clear warning to stderr when an unknown format is supplied, then fall back to JSON
- Added unit tests for both the happy path and the unknown-format error path
- `from_str` is retained as a convenience wrapper (silent fallback) for any internal callers