### PR TITLE
fix: add github.com instead of just github in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The repo ships 100+ Agent Skills (`SKILL.md` files) — one for every supported 
 
 ```bash
 # Install all skills at once
-npx skills add github.com:googleworkspace/cli
+npx skills add https://github.com/googleworkspace/cli
 
 # Or pick only what you need
 npx skills add https://github.com/googleworkspace/cli/tree/main/skills/gws-drive


### PR DESCRIPTION
## Description

The existing README command to install skills fails with the following error. Fixing the hostname to `github.com`

<details><summary>Error</summary>
<p>

```sh
> npx skills add github:googleworkspace/cli

███████╗██╗  ██╗██╗██╗     ██╗     ███████╗
██╔════╝██║ ██╔╝██║██║     ██║     ██╔════╝
███████╗█████╔╝ ██║██║     ██║     ███████╗
╚════██║██╔═██╗ ██║██║     ██║     ╚════██║
███████║██║  ██╗██║███████╗███████╗███████║
╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝╚══════╝

┌   skills
│
◇  Source: github:googleworkspace/cli
│
◒  Cloning repository│
■  Failed to clone repository
│
│  Failed to clone github:googleworkspace/cli: Cloning into '/var/folders/z4/hdvs0wyx3hsgmt7j31w_d2w40000gn/T/skills-J9vhW4'...
│
│  ssh: Could not resolve hostname github: nodename nor servname provided, or not known
│
│  fatal: Could not read from remote repository.
│
│
│
│  Please make sure you have the correct access rights
│
│  and the repository exists.
```

</p>
</details> 
