### PR TITLE
fix: resolve Clippy warnings

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -891,7 +891,7 @@ mod tests {
     #[test]
     fn test_pagination_config_default() {
         let config = PaginationConfig::default();
-        assert_eq!(config.page_all, false);
+        assert!(!config.page_all);
         assert_eq!(config.page_limit, 10);
         assert_eq!(config.page_delay_ms, 100);
     }

--- a/src/helpers/chat.rs
+++ b/src/helpers/chat.rs
@@ -201,8 +201,10 @@ mod tests {
             },
         );
 
-        let mut messages_res = RestResource::default();
-        messages_res.methods = methods;
+        let messages_res = RestResource {
+            methods,
+            ..Default::default()
+        };
 
         let mut spaces_res = RestResource::default();
         spaces_res

--- a/src/helpers/docs.rs
+++ b/src/helpers/docs.rs
@@ -172,8 +172,10 @@ mod tests {
             },
         );
 
-        let mut documents_res = RestResource::default();
-        documents_res.methods = methods;
+        let documents_res = RestResource {
+            methods,
+            ..Default::default()
+        };
 
         let mut resources = HashMap::new();
         resources.insert("documents".to_string(), documents_res);

--- a/src/helpers/sheets.rs
+++ b/src/helpers/sheets.rs
@@ -328,8 +328,10 @@ mod tests {
             },
         );
 
-        let mut values_res = RestResource::default();
-        values_res.methods = methods;
+        let values_res = RestResource {
+            methods,
+            ..Default::default()
+        };
 
         let mut spreadsheets_res = RestResource::default();
         spreadsheets_res

--- a/src/main.rs
+++ b/src/main.rs
@@ -432,7 +432,7 @@ mod tests {
             .get_matches_from(vec!["test"]);
 
         let config = parse_pagination_config(&matches);
-        assert_eq!(config.page_all, false);
+        assert!(!config.page_all);
         assert_eq!(config.page_limit, 10);
         assert_eq!(config.page_delay_ms, 100);
     }
@@ -465,7 +465,7 @@ mod tests {
             ]);
 
         let config = parse_pagination_config(&matches);
-        assert_eq!(config.page_all, true);
+        assert!(config.page_all);
         assert_eq!(config.page_limit, 20);
         assert_eq!(config.page_delay_ms, 500);
     }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1574,7 +1574,7 @@ mod tests {
                 continue;
             }
             assert!(
-                api_ids.iter().any(|id| *id == expected_suffix),
+                api_ids.contains(&expected_suffix),
                 "Missing API ID for service '{}' (expected {})",
                 entry.api_name,
                 expected_suffix


### PR DESCRIPTION
This PR fixes the following Clippy warnings:

- Replace `assert_eq!` with literal bool to `assert!` or `assert!(!)`
- Use struct initialization instead of field reassignment after `Default::default()`
- Use `contains()` instead of `iter().any()` for better efficiency

All changes follow Clippy's suggestions for better code quality and performance.