### PR TITLE
test: add coverage for helper dispatch and service alias resolution

### DIFF
--- a/.changeset/test-helper-service-coverage.md
+++ b/.changeset/test-helper-service-coverage.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Add tests for helper module dispatch and service alias resolution edge cases

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -63,3 +63,52 @@ pub fn get_helper(service: &str) -> Option<Box<dyn Helper>> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_helper_known_services() {
+        let known = [
+            "gmail",
+            "sheets",
+            "docs",
+            "chat",
+            "drive",
+            "calendar",
+            "script",
+            "apps-script",
+            "workspaceevents",
+            "modelarmor",
+            "workflow",
+        ];
+        for service in known {
+            assert!(
+                get_helper(service).is_some(),
+                "expected helper for '{service}'"
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_helper_unknown_returns_none() {
+        assert!(get_helper("unknown").is_none());
+        assert!(get_helper("").is_none());
+        assert!(get_helper("Gmail").is_none()); // case-sensitive
+    }
+
+    #[test]
+    fn test_get_helper_script_alias() {
+        // Both "script" and "apps-script" should return a helper
+        assert!(get_helper("script").is_some());
+        assert!(get_helper("apps-script").is_some());
+    }
+
+    #[test]
+    fn test_helper_default_not_helper_only() {
+        // Default implementation of helper_only() should return false
+        let helper = get_helper("gmail").unwrap();
+        assert!(!helper.helper_only());
+    }
+}

--- a/src/services.rs
+++ b/src/services.rs
@@ -215,12 +215,63 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_service_all_aliases() {
+        // Verify every alias in SERVICES resolves correctly
+        for entry in SERVICES {
+            for alias in entry.aliases {
+                let (api_name, version) = resolve_service(alias)
+                    .unwrap_or_else(|_| panic!("alias '{}' should resolve", alias));
+                assert_eq!(api_name, entry.api_name, "alias '{}' wrong api_name", alias);
+                assert_eq!(version, entry.version, "alias '{}' wrong version", alias);
+            }
+        }
+    }
+
+    #[test]
     fn test_resolve_service_unknown() {
         let err = resolve_service("unknown_service");
         assert!(err.is_err());
         match err.unwrap_err() {
             GwsError::Validation(msg) => assert!(msg.contains("Unknown service")),
             _ => panic!("Expected Validation error"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_service_case_sensitive() {
+        // Service names should be case-sensitive
+        assert!(resolve_service("Drive").is_err());
+        assert!(resolve_service("GMAIL").is_err());
+    }
+
+    #[test]
+    fn test_resolve_service_empty_string() {
+        assert!(resolve_service("").is_err());
+    }
+
+    #[test]
+    fn test_resolve_service_error_lists_known_services() {
+        let err = resolve_service("nonexistent");
+        match err.unwrap_err() {
+            GwsError::Validation(msg) => {
+                assert!(msg.contains("drive"), "error should list 'drive': {msg}");
+                assert!(msg.contains("gmail"), "error should list 'gmail': {msg}");
+            }
+            _ => panic!("Expected Validation error"),
+        }
+    }
+
+    #[test]
+    fn test_no_duplicate_aliases() {
+        let mut seen = std::collections::HashSet::new();
+        for entry in SERVICES {
+            for alias in entry.aliases {
+                assert!(
+                    seen.insert(*alias),
+                    "duplicate alias '{}' found in SERVICES",
+                    alias
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add unit tests for `helpers::get_helper()` — previously untested
- Expand `services::resolve_service()` test coverage with edge cases

## New Tests

### `helpers/mod.rs`
- `test_get_helper_known_services` — all 11 service names return a helper
- `test_get_helper_unknown_returns_none` — unknown/empty/wrong-case returns None
- `test_get_helper_script_alias` — both "script" and "apps-script" work
- `test_helper_default_not_helper_only` — default trait impl returns false

### `services.rs`
- `test_resolve_service_all_aliases` — exhaustively tests every alias in SERVICES
- `test_resolve_service_case_sensitive` — "Drive" and "GMAIL" should fail
- `test_resolve_service_empty_string` — empty string should fail
- `test_resolve_service_error_lists_known_services` — error message includes available services
- `test_no_duplicate_aliases` — ensures no alias appears twice in SERVICES

## Test plan

- [ ] `cargo test` passes (CI will verify)
- [ ] `cargo clippy -- -D warnings` clean (CI will verify)