### PR TITLE
fix: add x86_64-unknown-linux-musl build target

### DIFF
--- a/.changeset/fix-linux-musl-install.md
+++ b/.changeset/fix-linux-musl-install.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Add `x86_64-unknown-linux-musl` build target for Linux musl/static binary support

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -30,7 +30,7 @@ npm-scope = "@googleworkspace"
 github-attestations = true
 npm-package = "cli"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
 # Don't overwrite release.yml on `cargo dist init` (preserves custom npm registry config)


### PR DESCRIPTION
## Summary

- Add `x86_64-unknown-linux-musl` to cargo-dist build targets in `dist-workspace.toml`
- Fixes npm install failure on musl-based Linux systems (Alpine, NixOS, Docker scratch)

Fixes #86

## Problem

When installing via npm on a musl-based Linux system, the install script detects glibc incompatibility and tries to fall back to a static musl binary. However, no musl target was configured, so the fallback fails with:

```
Platform with type "Linux" and architecture "x64" is not supported
```

## Solution

Add `x86_64-unknown-linux-musl` to the targets list so cargo-dist builds and publishes a statically-linked musl binary alongside the glibc variant. The npm install script's existing musl fallback logic will then find and use this binary.

## Test plan

- [ ] CI release pipeline builds the musl target successfully
- [ ] npm install works on Alpine Linux / musl-based containers