### PR TITLE
feat: add Homebrew installer via cargo-dist

### DIFF
--- a/.changeset/feat-homebrew-installer.md
+++ b/.changeset/feat-homebrew-installer.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": minor
+---
+
+Add Homebrew installer support via cargo-dist

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -22,7 +22,9 @@ cargo-dist-version = "0.31.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["shell", "powershell", "npm"]
+installers = ["shell", "powershell", "npm", "homebrew"]
+# Homebrew tap repository for `brew install gws`
+tap = "googleworkspace/homebrew-tap"
 # Publish jobs to run
 publish-jobs = ["npm"]
 npm-scope = "@googleworkspace"


### PR DESCRIPTION
## Summary

- Enable the cargo-dist `homebrew` installer in `dist-workspace.toml`
- Configure tap repository as `googleworkspace/homebrew-tap`

Addresses #90

## How it works

cargo-dist [natively supports Homebrew](https://axodotdev.github.io/cargo-dist/book/installers/homebrew.html) — adding `"homebrew"` to the installers list makes the release workflow automatically generate and push a Homebrew formula to the configured tap repo.

## Prerequisites

A `googleworkspace/homebrew-tap` repository needs to be created on GitHub (can be empty) with write access from the release workflow. The tap name is configurable — happy to adjust if the team prefers a different naming convention.

## Usage (after setup)

```bash
brew tap googleworkspace/homebrew-tap
brew install gws
```

## Test plan

- [ ] Verify cargo-dist generates a valid Homebrew formula in CI plan mode
- [ ] Create tap repo and test end-to-end install on macOS