### PR TITLE
fix: reject DEL character (0x7F) in input validation

### DIFF
--- a/.changeset/fix-reject-del-char.md
+++ b/.changeset/fix-reject-del-char.md
@@ -1,0 +1,9 @@
+---
+"@googleworkspace/cli": patch
+---
+
+fix: reject DEL character (0x7F) in input validation
+
+The `reject_control_chars` helper rejected bytes 0x00–0x1F but allowed
+the DEL character (0x7F), which is also an ASCII control character. This
+could allow malformed input from LLM agents to bypass validation.

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -118,9 +118,10 @@ pub fn validate_safe_dir_path(dir: &str) -> Result<PathBuf, GwsError> {
     Ok(canonical)
 }
 
-/// Rejects strings containing null bytes or ASCII control characters.
+/// Rejects strings containing null bytes or ASCII control characters
+/// (including DEL, 0x7F).
 fn reject_control_chars(value: &str, flag_name: &str) -> Result<(), GwsError> {
-    if value.bytes().any(|b| b < 0x20) {
+    if value.bytes().any(|b| b < 0x20 || b == 0x7F) {
         return Err(GwsError::Validation(format!(
             "{flag_name} contains invalid control characters"
         )));
@@ -366,6 +367,11 @@ mod tests {
     #[test]
     fn test_reject_control_chars_newline() {
         assert!(reject_control_chars("hello\nworld", "test").is_err());
+    }
+
+    #[test]
+    fn test_reject_control_chars_del() {
+        assert!(reject_control_chars("hello\x7Fworld", "test").is_err());
     }
 
     // -- encode_path_segment --------------------------------------------------


### PR DESCRIPTION
## Description

The `reject_control_chars` helper in `validate.rs` rejected bytes `0x00–0x1F` but allowed the DEL character (`0x7F`), which is also an ASCII control character. Since this CLI is designed to be invoked by LLM agents, malformed input containing DEL could bypass validation.

- Added `|| b == 0x7F` to the existing byte check
- Added a test case for DEL character rejection

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.