### PR TITLE
fix: add manual project ID entry to setup project picker

### DIFF
--- a/.changeset/project-manual-entry.md
+++ b/.changeset/project-manual-entry.md
@@ -1,0 +1,9 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Add "Enter project ID manually" option to project picker in `gws auth setup`.
+
+Users with large numbers of GCP projects often hit the 10-second listing timeout.
+The picker now includes a "⌨ Enter project ID manually" item so users can type a
+known project ID directly without waiting for `gcloud projects list` to complete.

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -989,14 +989,24 @@ fn stage_project(ctx: &mut SetupContext) -> Result<SetupStage, GwsError> {
         }
         let current = get_gcloud_project()?.unwrap_or_default();
 
-        let mut items: Vec<SelectItem> = vec![SelectItem {
-            label: "➕ Create new project".to_string(),
-            description: "Create a new GCP project for gws".to_string(),
-            selected: false,
-            is_fixed: false,
-            is_template: false,
-            template_selects: vec![],
-        }];
+        let mut items: Vec<SelectItem> = vec![
+            SelectItem {
+                label: "➕ Create new project".to_string(),
+                description: "Create a new GCP project for gws".to_string(),
+                selected: false,
+                is_fixed: false,
+                is_template: false,
+                template_selects: vec![],
+            },
+            SelectItem {
+                label: "⌨ Enter project ID manually".to_string(),
+                description: "Use an existing project ID you already know".to_string(),
+                selected: false,
+                is_fixed: false,
+                is_template: false,
+                template_selects: vec![],
+            },
+        ];
         items.extend(projects.iter().map(|(id, name)| SelectItem {
             label: id.clone(),
             description: name.clone(),
@@ -1059,6 +1069,30 @@ fn stage_project(ctx: &mut SetupContext) -> Result<SetupStage, GwsError> {
                         set_gcloud_project(&project_name)?;
                         ctx.wiz(2, StepStatus::Done(project_name.clone()));
                         ctx.project_id = project_name;
+                        Ok(SetupStage::EnableApis)
+                    }
+                    Some(item) if item.label.starts_with('⌨') => {
+                        let project_id = match ctx
+                            .wizard
+                            .as_mut()
+                            .unwrap()
+                            .show_input(
+                                "Enter GCP project ID",
+                                "Type your existing project ID",
+                                None,
+                            )
+                            .map_err(|e| GwsError::Validation(format!("TUI error: {e}")))?
+                        {
+                            crate::setup_tui::InputResult::Confirmed(v) if !v.is_empty() => v,
+                            _ => {
+                                return Err(GwsError::Validation(
+                                    "Project entry cancelled by user".to_string(),
+                                ))
+                            }
+                        };
+                        set_gcloud_project(&project_id)?;
+                        ctx.wiz(2, StepStatus::Done(project_id.clone()));
+                        ctx.project_id = project_id;
                         Ok(SetupStage::EnableApis)
                     }
                     Some(item) => {
@@ -1466,6 +1500,7 @@ mod tests {
         LoginNewAccount,
         SetProject(String),
         CreateProject(String),
+        EnterProjectId,
         EnableApis(Vec<String>),
         NoSelection,
     }
@@ -1483,6 +1518,7 @@ mod tests {
             Some(item) if item.label.starts_with('➕') => {
                 SetupAction::CreateProject(String::new())
             }
+            Some(item) if item.label.starts_with('⌨') => SetupAction::EnterProjectId,
             Some(item) => SetupAction::SetProject(item.label.clone()),
             None => SetupAction::NoSelection,
         }
@@ -1674,6 +1710,20 @@ mod tests {
         assert_eq!(
             resolve_project_selection(&items),
             SetupAction::CreateProject(String::new())
+        );
+    }
+
+    #[test]
+    fn test_project_select_enter_manually() {
+        let mut items = make_items(&[
+            "➕ Create new project",
+            "⌨ Enter project ID manually",
+            "existing",
+        ]);
+        items[1].selected = true;
+        assert_eq!(
+            resolve_project_selection(&items),
+            SetupAction::EnterProjectId
         );
     }
 


### PR DESCRIPTION
## Description

Fixes #116

Users with large numbers of GCP projects frequently hit the 10-second listing timeout in `gws auth setup`:

> Could not list projects: Timed out listing projects (10s)

After this error, the project picker only showed "➕ Create new project" — forcing users to create a new project even if they already have one they want to use.

This PR adds a **"⌨ Enter project ID manually"** option to the project picker. When selected, the user is prompted to type their existing project ID directly, bypassing `gcloud projects list` entirely.

**Dry Run Output:**
```json
// Not applicable — TUI flow change, no HTTP request
```

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [ ] I have run `cargo fmt --all` to format the code perfectly. *(no Rust toolchain on build host — CI will verify)*
- [ ] I have run `cargo clippy -- -D warnings` and resolved all warnings. *(CI will verify)*
- [x] I have added tests that prove my fix is effective or that my feature works. (`test_project_select_enter_manually`)
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.

---
🤖 Generated with Claude Code