### PR TITLE
Fix/warn credential permission failures

### DIFF
--- a/.changeset/fix-credential-permission-warnings.md
+++ b/.changeset/fix-credential-permission-warnings.md
@@ -1,0 +1,10 @@
+---
+"@googleworkspace/cli": patch
+---
+
+fix: warn on credential file permission failures instead of ignoring
+
+Replaced silent `let _ =` on `set_permissions` calls in `save_encrypted`
+with `eprintln!` warnings so users are aware if their credential files
+end up with insecure permissions. Also log keyring access failures
+instead of silently falling through to file storage.

--- a/src/credential_store.rs
+++ b/src/credential_store.rs
@@ -119,7 +119,9 @@ fn get_or_create_key() -> anyhow::Result<[u8; 32]> {
 
                 return Ok(cache_key(key));
             }
-            Err(_) => {} // Fallthrough to file storage
+            Err(e) => {
+                eprintln!("Warning: keyring access failed, falling back to file storage: {e}");
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Replaced silent `let _ =` on `set_permissions` calls in `save_encrypted()` with `eprintln!` warnings so users are aware if their credential files end up with insecure permissions. Also log keyring access failures instead of silently falling through to file storage.

This follows the existing pattern already used in `get_or_create_key()` (lines 92-98) where permission failures are properly warned about.

**Changes:**
- `save_encrypted`: Warn if directory permissions (0o700) fail to set
- `save_encrypted`: Warn if credentials file permissions (0o600) fail to set
- `get_or_create_key`: Log keyring errors instead of silently ignoring them

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.