### PR TITLE
fix: exclude Workspace-admin-only scopes from Recommended preset

### DIFF
--- a/.changeset/admin-scopes-recommended.md
+++ b/.changeset/admin-scopes-recommended.md
@@ -1,0 +1,17 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Exclude Workspace-admin-only scopes from the "Recommended" scope preset.
+
+Scopes that require Google Workspace domain-admin access (`apps.*`,
+`cloud-identity.*`, `ediscovery`, `directory.readonly`, `groups`) now return
+`400 invalid_scope` when used by personal `@gmail.com` accounts. These scopes
+are no longer included in the "Recommended" template, preventing login failures
+for non-Workspace users.
+
+Workspace admins can still select these scopes manually via the "Full Access"
+template or by picking them individually in the scope picker.
+
+Adds a new `is_workspace_admin_scope()` helper (mirroring the existing
+`is_app_only_scope()`) that centralises this detection logic.

--- a/src/auth_commands.rs
+++ b/src/auth_commands.rs
@@ -427,7 +427,10 @@ fn run_discovery_scope_picker(
             entry.classification != ScopeClassification::Restricted
         };
 
-        if is_recommended && !entry.short.starts_with("admin.") {
+        if is_recommended
+            && !entry.short.starts_with("admin.")
+            && !is_workspace_admin_scope(&entry.url)
+        {
             recommended_scopes.push(entry.short.to_string());
         }
         if entry.is_readonly {
@@ -542,12 +545,16 @@ fn run_discovery_scope_picker(
                     selected.push(entry.url.to_string());
                 }
             } else if recommended && !full && !readonly {
-                // Recommended: non-restricted + readonly, but exclude admin.* scopes
+                // Recommended: non-restricted + readonly, but exclude admin.* and
+                // Workspace-admin-only scopes (require domain admin; fail for @gmail.com).
                 for entry in relevant_scopes {
                     if is_app_only_scope(&entry.url) {
                         continue;
                     }
                     if entry.short.starts_with("admin.") {
+                        continue;
+                    }
+                    if is_workspace_admin_scope(&entry.url) {
                         continue;
                     }
                     if entry.is_readonly || entry.classification != ScopeClassification::Restricted
@@ -1042,6 +1049,30 @@ fn is_app_only_scope(url: &str) -> bool {
         || url.contains("/auth/keep")
 }
 
+/// Helper: check if a scope requires Workspace domain admin access and therefore
+/// cannot be granted to personal `@gmail.com` accounts via standard user OAuth.
+///
+/// These scopes are valid in Workspace environments with a domain admin, but
+/// Google returns `400 invalid_scope` when requested by personal accounts.
+/// They are excluded from the "Recommended" preset to avoid login failures.
+///
+/// Affected scope families:
+/// - `apps.*`            — Alert Center, Groups Settings, Licensing, Reseller
+/// - `cloud-identity.*`  — Cloud Identity: devices, groups, inbound SSO, policies
+/// - `ediscovery`        — Google Vault
+/// - `directory.readonly`— Admin SDK Directory (read-only)
+/// - `groups`            — Groups Management
+fn is_workspace_admin_scope(url: &str) -> bool {
+    let short = url
+        .strip_prefix("https://www.googleapis.com/auth/")
+        .unwrap_or(url);
+    short.starts_with("apps.")
+        || short.starts_with("cloud-identity.")
+        || short == "ediscovery"
+        || short == "directory.readonly"
+        || short == "groups"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1320,5 +1351,82 @@ mod tests {
         // HashMap<String, TokenInfo> format from EncryptedTokenStorage
         let data = r#"{"key":{"access_token":"ya29","refresh_token":"1//tok"}}"#;
         assert_eq!(extract_refresh_token(data), Some("1//tok".to_string()));
+    }
+
+    // ── is_workspace_admin_scope tests ──────────────────────────────────
+
+    #[test]
+    fn is_workspace_admin_scope_apps_alerts() {
+        assert!(is_workspace_admin_scope(
+            "https://www.googleapis.com/auth/apps.alerts"
+        ));
+    }
+
+    #[test]
+    fn is_workspace_admin_scope_apps_groups_settings() {
+        assert!(is_workspace_admin_scope(
+            "https://www.googleapis.com/auth/apps.groups.settings"
+        ));
+    }
+
+    #[test]
+    fn is_workspace_admin_scope_apps_licensing() {
+        assert!(is_workspace_admin_scope(
+            "https://www.googleapis.com/auth/apps.licensing"
+        ));
+    }
+
+    #[test]
+    fn is_workspace_admin_scope_cloud_identity() {
+        assert!(is_workspace_admin_scope(
+            "https://www.googleapis.com/auth/cloud-identity.groups"
+        ));
+        assert!(is_workspace_admin_scope(
+            "https://www.googleapis.com/auth/cloud-identity.devices"
+        ));
+        assert!(is_workspace_admin_scope(
+            "https://www.googleapis.com/auth/cloud-identity.policies"
+        ));
+    }
+
+    #[test]
+    fn is_workspace_admin_scope_ediscovery() {
+        assert!(is_workspace_admin_scope(
+            "https://www.googleapis.com/auth/ediscovery"
+        ));
+    }
+
+    #[test]
+    fn is_workspace_admin_scope_directory_readonly() {
+        assert!(is_workspace_admin_scope(
+            "https://www.googleapis.com/auth/directory.readonly"
+        ));
+    }
+
+    #[test]
+    fn is_workspace_admin_scope_groups() {
+        assert!(is_workspace_admin_scope(
+            "https://www.googleapis.com/auth/groups"
+        ));
+    }
+
+    #[test]
+    fn is_workspace_admin_scope_normal_scopes_not_admin() {
+        // Consumer/personal-account scopes must NOT be classified as admin-only
+        assert!(!is_workspace_admin_scope(
+            "https://www.googleapis.com/auth/drive"
+        ));
+        assert!(!is_workspace_admin_scope(
+            "https://www.googleapis.com/auth/gmail.modify"
+        ));
+        assert!(!is_workspace_admin_scope(
+            "https://www.googleapis.com/auth/calendar"
+        ));
+        assert!(!is_workspace_admin_scope(
+            "https://www.googleapis.com/auth/spreadsheets"
+        ));
+        assert!(!is_workspace_admin_scope(
+            "https://www.googleapis.com/auth/chat.messages"
+        ));
     }
 }


### PR DESCRIPTION
## Description

Addresses #119 (Bug 1: admin-only scopes causing `400 invalid_scope` for personal @gmail.com accounts)

### Problem

When `gws auth login` is run and the user selects the "Recommended" scope preset, admin-only scopes are included in the OAuth request. Google rejects these with `400 invalid_scope` for personal `@gmail.com` accounts because they require Workspace domain-admin access:

- `apps.alerts`, `apps.groups.settings`, `apps.licensing`, `apps.order`
- `cloud-identity.devices`, `cloud-identity.groups`, `cloud-identity.inboundsso`, `cloud-identity.policies`
- `ediscovery` (Vault)
- `directory.readonly` (Admin SDK)
- `groups` (Groups Management)

These scopes are only shown when the user has enabled their corresponding APIs (Vault, Groups Settings, Cloud Identity, etc.) in their GCP project, but they silently break the OAuth flow for personal accounts.

### Solution

Adds an `is_workspace_admin_scope()` helper (mirroring the existing `is_app_only_scope()`) and uses it to exclude admin-only scopes from:

1. The **template_selects** of the "Recommended" preset (so they're not pre-checked)
2. The **resolved scope list** when the Recommended template is confirmed

Workspace admins who legitimately need these scopes can still access them via the "⚠️ Full Access" template or by selecting them individually in the picker.

### Relationship to PR #108

PR #108 filters alertcenter scopes at the API-discovery level (one specific family). This PR handles the broader set at the **recommendation layer** — no scopes are hidden from the picker, they're just not pre-selected in the Recommended template. The two approaches are complementary.

**Dry Run Output:**
```json
// Not applicable — scope recommendation logic change, no HTTP request generated
```

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [ ] I have run `cargo fmt --all` to format the code perfectly. *(no Rust toolchain on build host — CI will verify)*
- [ ] I have run `cargo clippy -- -D warnings` and resolved all warnings. *(CI will verify)*
- [x] I have added tests that prove my fix is effective or that my feature works. (8 unit tests for `is_workspace_admin_scope()`)
- [x] I have provided a Changeset file to document my changes.

---
🤖 Generated with Claude Code