### PR TITLE
fix: fix gws auth login for personal @gmail.com accounts

### DIFF
--- a/.changeset/fix-personal-account-auth.md
+++ b/.changeset/fix-personal-account-auth.md
@@ -1,0 +1,33 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Fix `gws auth login` unusable with personal @gmail.com accounts (closes #119)
+
+Two separate bugs compounded to make authentication impossible for personal users:
+
+**Bug 1 — Workspace-admin scopes in "Recommended" preset**
+
+The "Recommended" scope preset included admin-only scopes
+(`apps.alerts`, `apps.groups.settings`, `cloud-identity.*`, `ediscovery`,
+`directory.*`, `groups`, `chat.admin.*`, `classroom.*`) that Google rejects
+with `400 invalid_scope` for personal `@gmail.com` accounts.
+
+Added `is_workspace_admin_scope()` which filters these from the Recommended
+preset and from the picker UI. They remain available via `--full` or `--scopes`
+for Workspace domain admins who explicitly need them.
+
+**Bug 2 — Custom `client_secret.json` silently ignored on macOS / Windows**
+
+On macOS and Windows `dirs::config_dir()` resolves to a different path than
+`~/.config/` (which the README documents for Linux). Users who followed the
+README instructions on macOS placed the file at `~/.config/gws/client_secret.json`
+but the CLI looked in `~/Library/Application Support/gws/` and silently failed.
+
+`load_client_config()` now searches in this order:
+
+1. `GOOGLE_WORKSPACE_CLI_CLIENT_SECRET_FILE` env var (explicit path override)
+2. Platform-native config dir (existing behaviour)
+3. `~/.config/gws/client_secret.json` XDG fallback (new — catches macOS/Windows users following Linux docs)
+
+The error message now shows the actual OS-specific expected path.

--- a/src/auth_commands.rs
+++ b/src/auth_commands.rs
@@ -427,7 +427,7 @@ fn run_discovery_scope_picker(
             entry.classification != ScopeClassification::Restricted
         };
 
-        if is_recommended && !entry.short.starts_with("admin.") {
+        if is_recommended && !entry.short.starts_with("admin.") && !is_workspace_admin_scope(&entry.url) {
             recommended_scopes.push(entry.short.to_string());
         }
         if entry.is_readonly {
@@ -547,7 +547,7 @@ fn run_discovery_scope_picker(
                     if is_app_only_scope(&entry.url) {
                         continue;
                     }
-                    if entry.short.starts_with("admin.") {
+                    if entry.short.starts_with("admin.") || is_workspace_admin_scope(&entry.url) {
                         continue;
                     }
                     if entry.is_readonly || entry.classification != ScopeClassification::Restricted
@@ -1042,6 +1042,32 @@ fn is_app_only_scope(url: &str) -> bool {
         || url.contains("/auth/keep")
 }
 
+/// Returns `true` if a scope requires Google Workspace admin access or
+/// domain-wide delegation and will **always** fail with `400 invalid_scope`
+/// for personal `@gmail.com` accounts.
+///
+/// These scopes are intentionally excluded from the "Recommended" preset so
+/// that personal-account users don't hit auth errors on first login.
+/// They remain available via `--full` or an explicit `--scopes` flag once
+/// the user knows they have a Workspace domain.
+pub fn is_workspace_admin_scope(url: &str) -> bool {
+    const ADMIN_PREFIXES: &[&str] = &[
+        "/auth/apps.alerts",
+        "/auth/apps.groups.settings",
+        "/auth/apps.licensing",
+        "/auth/apps.order",
+        "/auth/cloud-identity.",
+        "/auth/ediscovery",
+        "/auth/directory.",
+        // Admin SDK Groups (different from personal Google Groups)
+        "/auth/groups",
+        "/auth/chat.admin.",
+        // Google Classroom requires an institution/education domain
+        "/auth/classroom.",
+    ];
+    ADMIN_PREFIXES.iter().any(|&p| url.contains(p))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1320,5 +1346,53 @@ mod tests {
         // HashMap<String, TokenInfo> format from EncryptedTokenStorage
         let data = r#"{"key":{"access_token":"ya29","refresh_token":"1//tok"}}"#;
         assert_eq!(extract_refresh_token(data), Some("1//tok".to_string()));
+    }
+
+    #[test]
+    fn test_is_workspace_admin_scope_matches_reported_scopes() {
+        // All scopes reported in Issue #119 must be filtered from Recommended.
+        let bad_scopes = [
+            "https://www.googleapis.com/auth/apps.alerts",
+            "https://www.googleapis.com/auth/apps.groups.settings",
+            "https://www.googleapis.com/auth/apps.licensing",
+            "https://www.googleapis.com/auth/apps.order",
+            "https://www.googleapis.com/auth/cloud-identity.devices",
+            "https://www.googleapis.com/auth/cloud-identity.groups",
+            "https://www.googleapis.com/auth/ediscovery",
+            "https://www.googleapis.com/auth/directory.readonly",
+            "https://www.googleapis.com/auth/groups",
+            "https://www.googleapis.com/auth/chat.admin.memberships",
+            "https://www.googleapis.com/auth/chat.admin.spaces",
+            "https://www.googleapis.com/auth/classroom.courses",
+        ];
+        for scope in &bad_scopes {
+            assert!(
+                is_workspace_admin_scope(scope),
+                "Expected {scope} to be flagged as workspace-admin scope"
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_workspace_admin_scope_passes_personal_scopes() {
+        // Scopes available to personal @gmail.com accounts must NOT be filtered.
+        let good_scopes = [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/gmail.modify",
+            "https://www.googleapis.com/auth/calendar",
+            "https://www.googleapis.com/auth/spreadsheets",
+            "https://www.googleapis.com/auth/documents",
+            "https://www.googleapis.com/auth/tasks",
+            "https://www.googleapis.com/auth/presentations",
+            "https://www.googleapis.com/auth/contacts",
+            "https://www.googleapis.com/auth/pubsub",
+            "https://www.googleapis.com/auth/chat.messages",
+        ];
+        for scope in &good_scopes {
+            assert!(
+                !is_workspace_admin_scope(scope),
+                "Expected {scope} to NOT be flagged as workspace-admin scope"
+            );
+        }
     }
 }

--- a/src/oauth_config.rs
+++ b/src/oauth_config.rs
@@ -95,13 +95,60 @@ pub fn save_client_config(
 }
 
 /// Loads OAuth client configuration from the standard Google Cloud Console format.
+///
+/// Search order:
+/// 1. `GOOGLE_WORKSPACE_CLI_CLIENT_SECRET_FILE` env var (explicit override)
+/// 2. Platform-specific config dir (`~/.config/gws/` on Linux,
+///    `~/Library/Application Support/gws/` on macOS, `AppData\Roaming\gws\` on Windows)
+/// 3. XDG fallback — `~/.config/gws/client_secret.json` — so that macOS / Windows
+///    users who follow the Linux README instructions are not silently broken.
 pub fn load_client_config() -> anyhow::Result<InstalledConfig> {
-    let path = client_config_path();
-    let data = std::fs::read_to_string(&path)
-        .map_err(|e| anyhow::anyhow!("Cannot read {}: {e}", path.display()))?;
-    let file: ClientSecretFile = serde_json::from_str(&data)
-        .map_err(|e| anyhow::anyhow!("Invalid client_secret.json format: {e}"))?;
-    Ok(file.installed)
+    // 1. Explicit env-var override (highest priority, cross-platform)
+    if let Ok(env_path) = std::env::var("GOOGLE_WORKSPACE_CLI_CLIENT_SECRET_FILE") {
+        let path = PathBuf::from(&env_path);
+        let data = std::fs::read_to_string(&path).map_err(|e| {
+            anyhow::anyhow!(
+                "Cannot read GOOGLE_WORKSPACE_CLI_CLIENT_SECRET_FILE ({env_path}): {e}"
+            )
+        })?;
+        let file: ClientSecretFile = serde_json::from_str(&data)
+            .map_err(|e| anyhow::anyhow!("Invalid client_secret.json format: {e}"))?;
+        return Ok(file.installed);
+    }
+
+    // 2. Platform-specific config dir (primary)
+    let primary = client_config_path();
+
+    // 3. XDG fallback: ~/.config/gws/client_secret.json
+    //    On macOS / Windows the platform dir differs from the Linux convention
+    //    documented in the README, causing silent failures when users follow the docs.
+    let xdg_fallback = dirs::home_dir()
+        .map(|h| h.join(".config").join("gws").join("client_secret.json"))
+        .filter(|p| *p != primary); // avoid trying the same path twice on Linux
+
+    for path in [Some(primary.clone()), xdg_fallback]
+        .into_iter()
+        .flatten()
+    {
+        if !path.exists() {
+            continue;
+        }
+        let data = std::fs::read_to_string(&path)
+            .map_err(|e| anyhow::anyhow!("Cannot read {}: {e}", path.display()))?;
+        let file: ClientSecretFile = serde_json::from_str(&data)
+            .map_err(|e| anyhow::anyhow!("Invalid client_secret.json format: {e}"))?;
+        return Ok(file.installed);
+    }
+
+    anyhow::bail!(
+        "client_secret.json not found.\n\
+         Expected location: {}\n\
+         Alternatives:\n\
+         - Save client_secret.json downloaded from Google Cloud Console to the path above\n\
+         - Set GOOGLE_WORKSPACE_CLI_CLIENT_SECRET_FILE=/path/to/client_secret.json\n\
+         - Run `gws auth setup` to configure interactively",
+        primary.display()
+    )
 }
 
 #[cfg(test)]
@@ -237,10 +284,14 @@ mod tests {
             dir.path().to_str().unwrap(),
         );
 
-        // Initially no config file exists
+        // Initially no config file exists — error should mention expected location
         let result = load_client_config();
         let err = result.unwrap_err();
-        assert!(err.to_string().contains("Cannot read"));
+        assert!(
+            err.to_string().contains("not found")
+                || err.to_string().contains("client_secret.json"),
+            "Unexpected error: {err}"
+        );
 
         // Create a valid config file
         save_client_config("test-id", "test-secret", "test-project").unwrap();
@@ -260,5 +311,32 @@ mod tests {
         assert!(err
             .to_string()
             .contains("Invalid client_secret.json format"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_load_client_config_from_env_var() {
+        // Write a valid client_secret.json to a temp file
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let json = r#"{
+            "installed": {
+                "client_id": "env-var-client-id",
+                "project_id": "env-project",
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://oauth2.googleapis.com/token",
+                "client_secret": "env-secret"
+            }
+        }"#;
+        std::fs::write(file.path(), json).unwrap();
+
+        let _guard = EnvGuard::new(
+            "GOOGLE_WORKSPACE_CLI_CLIENT_SECRET_FILE",
+            file.path().to_str().unwrap(),
+        );
+
+        let config = load_client_config().unwrap();
+        assert_eq!(config.client_id, "env-var-client-id");
+        assert_eq!(config.client_secret, "env-secret");
+        assert_eq!(config.project_id, "env-project");
     }
 }


### PR DESCRIPTION
Closes #119

## Summary

Two separate bugs compounded to make `gws auth login` fail for personal `@gmail.com` accounts.

## Bug 1 — Workspace-admin scopes in "Recommended" preset

The "Recommended" scope preset included admin-only scopes (`apps.alerts`, `cloud-identity.*`, `ediscovery`, `directory.*`, `chat.admin.*`) that Google rejects with `400 invalid_scope` for personal accounts. These are classified as `Sensitive` in the Discovery API so the existing filter passed them through.

Added `is_workspace_admin_scope()` which filters these from the "Recommended" preset. They remain available via `--full` for Workspace domain admins.

## Bug 2 — Custom `client_secret.json` silently ignored on macOS

On macOS, `dirs::config_dir()` resolves to `~/Library/Application Support/` not `~/.config/`. Users placing the file at `~/.config/gws/` (as the README says) were silently ignored.

`load_client_config()` now searches: env var `GOOGLE_WORKSPACE_CLI_CLIENT_SECRET_FILE` → platform dir → `~/.config/gws/` XDG fallback.

## Testing

Added 3 new unit tests covering all reported scopes and the env var override path.