### PR TITLE
fix: use reverse video for TUI highlight style

### DIFF
--- a/.changeset/fix-light-theme-highlight.md
+++ b/.changeset/fix-light-theme-highlight.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Fix highlight color on light terminal themes by using reverse video instead of a dark-gray background

--- a/src/setup_tui.rs
+++ b/src/setup_tui.rs
@@ -405,11 +405,7 @@ fn run_picker_loop(
                 .collect();
 
             let list = List::new(items)
-                .highlight_style(
-                    Style::default()
-                        .bg(Color::DarkGray)
-                        .add_modifier(Modifier::BOLD),
-                )
+                .highlight_style(Style::default().add_modifier(Modifier::REVERSED | Modifier::BOLD))
                 .highlight_symbol("▸ ");
 
             frame.render_stateful_widget(list, chunks[1], &mut state.list_state);
@@ -806,11 +802,7 @@ impl SetupWizard {
                     .borders(Borders::ALL)
                     .border_style(Style::default().fg(Color::DarkGray)),
             )
-            .highlight_style(
-                Style::default()
-                    .bg(Color::DarkGray)
-                    .add_modifier(Modifier::BOLD),
-            )
+            .highlight_style(Style::default().add_modifier(Modifier::REVERSED | Modifier::BOLD))
             .highlight_symbol("▸ ");
 
         frame.render_stateful_widget(list, area, &mut picker.list_state);


### PR DESCRIPTION
Replace bg(Color::DarkGray) with Modifier::REVERSED in highlight_style so the selected-row highlight adapts to both light and dark terminal themes.

<img width="400" height="387" alt="image" src="https://github.com/user-attachments/assets/129181bd-d708-41e3-a628-30f115051f2d" />

closes #139 


