### PR TITLE
fix: migrate to new Darwin SDK pattern in nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
 
         darwinDeps = with pkgs; [
           libiconv
-          darwin.apple_sdk.frameworks.Security
+          apple-sdk
         ];
 
         gws = pkgs.rustPlatform.buildRustPackage {


### PR DESCRIPTION
## Description

Replace removed `darwin.apple_sdk.frameworks.Security` with `apple-sdk`, following the nixpkgs Darwin SDK migration (NixOS/nixpkgs#354146).

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [ ] I have run `cargo fmt --all` to format the code perfectly.
- [ ] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.