### PR TITLE
Fix auth failures when accounts.json registry is missing

### DIFF
--- a/.changeset/fix-auth-legacy-credentials.md
+++ b/.changeset/fix-auth-legacy-credentials.md
@@ -1,0 +1,11 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Fix auth failures when accounts.json registry is missing
+
+Three related bugs caused all API calls to fail with "Access denied. No credentials provided" even after a successful `gws auth login`:
+
+1. `resolve_account()` rejected valid `credentials.enc` as "legacy" when `accounts.json` was absent, instead of using them.
+2. `main.rs` silently swallowed all auth errors, masking real failures behind a generic message.
+3. `auth login` didn't include `openid`/`email` scopes, so `fetch_userinfo_email()` couldn't identify the user, causing credentials to be saved without an `accounts.json` entry.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -131,18 +131,10 @@ fn resolve_account(account: Option<&str>) -> anyhow::Result<Option<String>> {
                 );
             }
         }
-        // No account, no registry — check for legacy credentials
+        // No account, no registry — use legacy credentials if they exist
         (None, None) => {
-            let legacy_path = credential_store::encrypted_credentials_path();
-            if legacy_path.exists() {
-                anyhow::bail!(
-                    "Legacy credentials found at {}. \
-                     gws now supports multiple accounts. \
-                     Please run 'gws auth login' to upgrade your credentials.",
-                    legacy_path.display()
-                );
-            }
-            // No registry, no legacy — fall through to standard credential loading
+            // Fall through to standard credential loading which will pick up
+            // the legacy credentials.enc file if it exists.
             Ok(None)
         }
     }
@@ -423,6 +415,88 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "my-test-token");
+    }
+
+    #[test]
+    fn test_resolve_account_no_registry_no_account_returns_none() {
+        // When there is no accounts.json and no explicit account,
+        // resolve_account should return Ok(None) to allow legacy
+        // credentials.enc to be picked up by load_credentials_inner.
+        let result = resolve_account(None);
+        // This will return Ok(None) if accounts.json doesn't exist,
+        // or Ok(Some(...)) if it does with a default. Either way, it
+        // should NOT error for the no-registry case.
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_load_credentials_encrypted_file() {
+        // Simulate an encrypted credentials file
+        let json = r#"{
+            "client_id": "enc_test_id",
+            "client_secret": "enc_test_secret",
+            "refresh_token": "enc_test_refresh",
+            "type": "authorized_user"
+        }"#;
+
+        let dir = tempfile::tempdir().unwrap();
+        let enc_path = dir.path().join("credentials.enc");
+
+        // Encrypt and write
+        let encrypted = crate::credential_store::encrypt(json.as_bytes()).unwrap();
+        std::fs::write(&enc_path, &encrypted).unwrap();
+
+        let res = load_credentials_inner(None, &enc_path, &PathBuf::from("/does/not/exist"))
+            .await
+            .unwrap();
+
+        match res {
+            Credential::AuthorizedUser(secret) => {
+                assert_eq!(secret.client_id, "enc_test_id");
+                assert_eq!(secret.client_secret, "enc_test_secret");
+                assert_eq!(secret.refresh_token, "enc_test_refresh");
+            }
+            _ => panic!("Expected AuthorizedUser from encrypted credentials"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_load_credentials_encrypted_takes_priority_over_default() {
+        // Encrypted credentials should be loaded before the default plaintext path
+        let enc_json = r#"{
+            "client_id": "encrypted_id",
+            "client_secret": "encrypted_secret",
+            "refresh_token": "encrypted_refresh",
+            "type": "authorized_user"
+        }"#;
+        let plain_json = r#"{
+            "client_id": "plaintext_id",
+            "client_secret": "plaintext_secret",
+            "refresh_token": "plaintext_refresh",
+            "type": "authorized_user"
+        }"#;
+
+        let dir = tempfile::tempdir().unwrap();
+        let enc_path = dir.path().join("credentials.enc");
+        let plain_path = dir.path().join("credentials.json");
+
+        let encrypted = crate::credential_store::encrypt(enc_json.as_bytes()).unwrap();
+        std::fs::write(&enc_path, &encrypted).unwrap();
+        std::fs::write(&plain_path, plain_json).unwrap();
+
+        let res = load_credentials_inner(None, &enc_path, &plain_path)
+            .await
+            .unwrap();
+
+        match res {
+            Credential::AuthorizedUser(secret) => {
+                assert_eq!(
+                    secret.client_id, "encrypted_id",
+                    "Encrypted credentials should take priority over plaintext"
+                );
+            }
+            _ => panic!("Expected AuthorizedUser"),
+        }
     }
 
     #[tokio::test]

--- a/src/auth_commands.rs
+++ b/src/auth_commands.rs
@@ -266,7 +266,7 @@ async fn handle_login(args: &[String]) -> Result<(), GwsError> {
     }
 
     // Determine scopes: explicit flags > interactive TUI > defaults
-    let scopes = resolve_scopes(
+    let mut scopes = resolve_scopes(
         &filtered_args,
         project_id.as_deref(),
         services_filter.as_ref(),
@@ -310,6 +310,15 @@ async fn handle_login(args: &[String]) -> Result<(), GwsError> {
     .build()
     .await
     .map_err(|e| GwsError::Auth(format!("Failed to build authenticator: {e}")))?;
+
+    // Ensure openid + email scopes are always present so we can identify the user
+    // via the userinfo endpoint after login.
+    let identity_scopes = ["openid", "https://www.googleapis.com/auth/userinfo.email"];
+    for s in &identity_scopes {
+        if !scopes.iter().any(|existing| existing == s) {
+            scopes.push(s.to_string());
+        }
+    }
 
     // Request a token — this triggers the browser OAuth flow
     let scope_refs: Vec<&str> = scopes.iter().map(|s| s.as_str()).collect();
@@ -2084,5 +2093,25 @@ mod tests {
         let empty: HashSet<String> = HashSet::new();
         let result = filter_scopes_by_services(scopes.clone(), Some(&empty));
         assert_eq!(result, scopes);
+    }
+
+    #[test]
+    fn mask_secret_long_string() {
+        let masked = mask_secret("GOCSPX-abcdefghijklmnopqrstuvwxyz");
+        assert_eq!(masked, "GOCS...wxyz");
+    }
+
+    #[test]
+    fn mask_secret_short_string() {
+        // 8 chars or fewer should be fully masked
+        assert_eq!(mask_secret("12345678"), "***");
+        assert_eq!(mask_secret("short"), "***");
+        assert_eq!(mask_secret(""), "***");
+    }
+
+    #[test]
+    fn mask_secret_boundary() {
+        // Exactly 9 chars — first 4 + last 4 with "..." in between
+        assert_eq!(mask_secret("123456789"), "1234...6789");
     }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1526,6 +1526,44 @@ mod tests {
     }
 
     #[test]
+    fn test_handle_error_response_401_with_oauth_does_not_mask_error() {
+        // When auth was attempted (OAuth) but the server still returns 401,
+        // the error should be an API error with the actual message, NOT
+        // the generic "Access denied. No credentials provided" message.
+        let json_err = json!({
+            "error": {
+                "code": 401,
+                "message": "Request had invalid authentication credentials.",
+                "errors": [{ "reason": "authError" }]
+            }
+        })
+        .to_string();
+
+        let err = handle_error_response::<()>(
+            reqwest::StatusCode::UNAUTHORIZED,
+            &json_err,
+            &AuthMethod::OAuth,
+        )
+        .unwrap_err();
+        match err {
+            GwsError::Api {
+                code,
+                message,
+                reason,
+                ..
+            } => {
+                assert_eq!(code, 401);
+                assert!(message.contains("invalid authentication credentials"));
+                assert_eq!(reason, "authError");
+            }
+            GwsError::Auth(msg) => {
+                panic!("Should NOT get generic Auth error when OAuth was used, got: {msg}");
+            }
+            other => panic!("Expected Api error, got: {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_handle_error_response_api_error() {
         let json_err = json!({
             "error": {

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,10 +235,20 @@ async fn run() -> Result<(), GwsError> {
     // Get scopes from the method
     let scopes: Vec<&str> = method.scopes.iter().map(|s| s.as_str()).collect();
 
-    // Authenticate: try OAuth, otherwise proceed unauthenticated
+    // Authenticate: try OAuth, fail with error if credentials exist but are broken
     let (token, auth_method) = match auth::get_token(&scopes, account.as_deref()).await {
         Ok(t) => (Some(t), executor::AuthMethod::OAuth),
-        Err(_) => (None, executor::AuthMethod::None),
+        Err(e) => {
+            // If credentials were found but failed (e.g. decryption error, invalid token),
+            // propagate the error instead of silently falling back to unauthenticated.
+            // Only fall back to None if no credentials exist at all.
+            let err_msg = format!("{e:#}");
+            if err_msg.starts_with("No credentials found") {
+                (None, executor::AuthMethod::None)
+            } else {
+                return Err(GwsError::Auth(format!("Authentication failed: {err_msg}")));
+            }
+        }
     };
 
     // Execute


### PR DESCRIPTION
## Description

Three related bugs caused **all API calls** to fail with _"Access denied. No credentials provided"_ even after a successful `gws auth login`. This happened when the userinfo endpoint couldn't identify the user's email (e.g. due to missing `openid`/`email` scopes), causing credentials to be saved to `credentials.enc` without an `accounts.json` registry entry — which then got immediately rejected as "legacy" credentials.

### Root Causes

1. **`resolve_account()` rejected valid `credentials.enc` as "legacy"** when `accounts.json` was absent, bailing with an error instead of falling through to use them.
2. **`main.rs` silently swallowed all auth errors** (`Err(_) => (None, AuthMethod::None)`), masking real failures behind the generic "no credentials" message.
3. **`auth login` didn't include `openid`/`email` scopes**, so `fetch_userinfo_email()` couldn't identify the user, causing credentials to be saved without an `accounts.json` entry.

### Fixes

- `src/auth.rs`: `resolve_account()` now returns `Ok(None)` when no registry exists, allowing `load_credentials_inner` to pick up `credentials.enc`.
- `src/main.rs`: Auth errors are now propagated unless the error is specifically "No credentials found". Real failures (decryption errors, invalid tokens, etc.) are shown to the user.
- `src/auth_commands.rs`: `handle_login` always injects `openid` and `userinfo.email` scopes so the user's email can be fetched and registered in `accounts.json`.

**Dry Run Output:**
```json
{
  "body": null,
  "dry_run": true,
  "is_multipart_upload": false,
  "method": "GET",
  "query_params": { "maxResults": "1" },
  "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages"
}
```

### Before (broken)
```
$ gws gmail users messages list --params '{"userId": "me", "maxResults": 3}'
{
  "error": {
    "code": 401,
    "message": "Access denied. No credentials provided...",
    "reason": "authError"
  }
}
```

### After (fixed)
```
$ gws gmail users messages list --params '{"userId": "me", "maxResults": 3}'
{
  "messages": [
    { "id": "19cbe9da792d0a86", "threadId": "193e10e9a6d45b5c" },
    ...
  ],
  "resultSizeEstimate": 201
}
```

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.