### PR TITLE
chore(docs): easier cmd to install from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Pre-built binaries are also available on the [GitHub Releases](https://github.co
 Or build from source:
 
 ```bash
-cargo install --git https://github.com/googleworkspace/cli
+cargo install --git https://github.com/googleworkspace/cli --locked
 ```
 
 A Nix flake is also available at `github:googleworkspace/cli`


### PR DESCRIPTION
## Description

Just a simpler way to install from source that does not require cloning the repo.

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.
