### PR TITLE
fix(setup): drain stale keypresses between TUI screen transitions

### DIFF
--- a/.changeset/drain-stale-keypresses.md
+++ b/.changeset/drain-stale-keypresses.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+fix(setup): drain stale keypresses between TUI screen transitions

--- a/src/setup_tui.rs
+++ b/src/setup_tui.rs
@@ -448,6 +448,15 @@ fn run_picker_loop(
     }
 }
 
+/// Drains any queued crossterm events to prevent stale keypresses from leaking
+/// between TUI interactions.
+fn drain_pending_events() -> std::io::Result<()> {
+    while crossterm::event::poll(std::time::Duration::ZERO)? {
+        let _ = event::read()?;
+    }
+    Ok(())
+}
+
 // ── Setup Wizard (unified TUI session) ──────────────────────────
 
 /// Status of a single setup step.
@@ -536,11 +545,7 @@ impl SetupWizard {
         multiselect: bool,
     ) -> std::io::Result<PickerResult> {
         let mut picker = PickerState::new(title, help_text, items, multiselect);
-        // Drain any queued key events from the previous interaction
-        // to prevent stale keypresses from leaking into the picker.
-        while crossterm::event::poll(std::time::Duration::ZERO)? {
-            let _ = event::read()?;
-        }
+        drain_pending_events()?;
         loop {
             let steps_snapshot = self.steps.clone();
             let msg = self.message.clone();
@@ -603,11 +608,7 @@ impl SetupWizard {
         initial: Option<&str>,
     ) -> std::io::Result<InputResult> {
         let mut input = InputState::new(title, help_text, initial);
-        // Drain any queued key events from the previous interaction
-        // to prevent stale keypresses from leaking into the input.
-        while crossterm::event::poll(std::time::Duration::ZERO)? {
-            let _ = event::read()?;
-        }
+        drain_pending_events()?;
         loop {
             let steps_snapshot = self.steps.clone();
             let msg = self.message.clone();


### PR DESCRIPTION
Stale `j` keypress from picker leaks into text input during `gws auth setup`, the API picker uses vim-style `j`/`k` for navigation. If you press `j` to move down, the `j` keypress sometimes leaks into the next screen's text input (the OAuth Client ID field). This appends a stray `j` to the pre-populated `client_id` value.

The corrupted `client_id` gets saved to `client_secret.json`, and all subsequent OAuth flows fail with `invalid_client` from Google. Took a while to figure out because the error doesn't point you to the client_id being wrong, you just get a generic OAuth failure. I only caught it after inspecting the saved credentials and noticing the trailing `j`.

Steps to reproduce:

1. Run `gws auth setup`
2. In the API picker, press `j` to navigate down, then quickly press Enter
3. On the next screen (Client ID input), the pre-populated value now has a `j` appended
4. If you don't notice and press Enter, the corrupted client_id is saved

`show_input()` in `setup_tui.rs` starts reading terminal events immediately without draining any queued events from the previous picker interaction. The buffered `j` keypress from the picker sits in crossterm's event queue and gets consumed by `InputState::handle_key`, which unconditionally pushes any `Char(c)` into the value string.

This PR drains pending events at the start of `show_input()` (and `show_picker()` defensively) before entering the event loop:

```rust
while crossterm::event::poll(std::time::Duration::ZERO)? {
    let _ = event::read()?;
}
```