### PR TITLE
fix: warn on stderr when discovery cache write fails

### DIFF
--- a/.changeset/fix-discovery-cache-warning.md
+++ b/.changeset/fix-discovery-cache-warning.md
@@ -1,0 +1,10 @@
+---
+"@anthropic/gws": patch
+---
+
+Warn on stderr when discovery cache write fails
+
+Previously, the error from writing the discovery document cache was
+silently discarded (`let _ = e`). Now prints a warning to stderr so
+users are aware their cache is not persisting (e.g., due to disk full
+or permission issues).

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -241,10 +241,9 @@ pub async fn fetch_discovery_document(
         alt_resp.text().await?
     };
 
-    // Write to cache
+    // Write to cache (non-fatal — warn if it fails)
     if let Err(e) = std::fs::write(&cache_file, &body) {
-        // Non-fatal: just warn via stderr-safe approach
-        let _ = e;
+        eprintln!("warning: failed to write discovery cache to {}: {}", cache_file.display(), e);
     }
 
     let doc: RestDescription = serde_json::from_str(&body)?;


### PR DESCRIPTION
## Summary

The comment on the cache write says "Non-fatal: just warn via stderr-safe approach" but the error was actually assigned to `_` and silently discarded. Now prints a warning to stderr with the file path and error, so users can diagnose cache persistence issues.

## Changes

- `src/discovery.rs`: Replace `let _ = e;` with `eprintln!` warning that includes the cache file path and error message

## Test plan

- [ ] CI: `cargo test`, `cargo clippy`, `cargo fmt`