### PR TITLE
feat: add native Factory Droid integration

### DIFF
--- a/.changeset/factory-droid-integration.md
+++ b/.changeset/factory-droid-integration.md
@@ -1,0 +1,10 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Add native Factory Droid integration.
+
+Ships a `.factory/skills/gws/SKILL.md` skill that teaches Factory Droid how to
+use the `gws` CLI (syntax, auth, field masks, pagination, safety rules), and a
+`.factory/droids/gws-contributor.md` development droid for project contributors.
+README updated with a Factory Droid setup section.

--- a/.factory/droids/gws-contributor.md
+++ b/.factory/droids/gws-contributor.md
@@ -1,0 +1,61 @@
+---
+name: gws-contributor
+description: Development helper for contributing to the gws Rust CLI. Knows the architecture, build commands, and coding conventions.
+model: inherit
+tools: ["Read", "Grep", "Glob", "LS", "Execute", "Edit", "Create"]
+---
+
+You are a development assistant for the `gws` CLI — a Rust project that dynamically generates its command surface from Google Discovery Documents.
+
+## Critical Rules
+
+- This project does NOT use generated Rust crates (e.g., `google-drive3`). It fetches Discovery JSON at runtime and builds clap commands dynamically.
+- When adding a new service, only register it in `src/services.rs` and verify the Discovery URL in `src/discovery.rs`. Do NOT add new crates to `Cargo.toml` for standard Google APIs.
+- Use `pnpm` instead of `npm` for Node.js package management.
+- Every PR must include a changeset file at `.changeset/<descriptive-name>.md`.
+
+## Build & Test
+
+```bash
+cargo build
+cargo clippy -- -D warnings
+cargo test
+```
+
+The `codecov/patch` CI check requires new or modified lines to be covered by tests. Extract testable helper functions rather than embedding logic in `main`/`run`.
+
+## Architecture
+
+Two-phase argument parsing:
+1. Parse argv to extract the service name
+2. Fetch the Discovery Document, build a dynamic `clap::Command` tree, then re-parse
+
+Key files:
+- `src/main.rs` — Entrypoint, two-phase parsing
+- `src/discovery.rs` — Discovery Document fetch/cache
+- `src/services.rs` — Service alias to API name/version mapping
+- `src/auth.rs` — OAuth2 token acquisition
+- `src/commands.rs` — Recursive clap::Command builder
+- `src/executor.rs` — HTTP request construction and response handling
+- `src/validate.rs` — Path and input validation helpers
+
+## Input Validation
+
+This CLI is frequently invoked by AI agents. Always assume inputs can be adversarial:
+- File paths: use `validate::validate_safe_output_dir()` / `validate_safe_dir_path()`
+- URL path segments: use `helpers::encode_path_segment()`
+- Resource names: use `helpers::validate_resource_name()`
+- Query parameters: use reqwest `.query()` builder
+- Enum flags: constrain via clap `value_parser`
+
+## Changeset Format
+
+```markdown
+---
+"@googleworkspace/cli": patch
+---
+
+Brief description of the change
+```
+
+Use `patch` for fixes/chores, `minor` for new features, `major` for breaking changes.

--- a/.factory/skills/gws/SKILL.md
+++ b/.factory/skills/gws/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: gws
+description: "Google Workspace CLI: Interact with Drive, Gmail, Calendar, Sheets, and all Workspace APIs using the gws command-line tool. Use when managing Google Workspace resources, sending emails, listing files, creating calendar events, or querying any Google API."
+---
+
+# gws — Google Workspace CLI
+
+`gws` provides dynamic access to every Google Workspace API (Drive, Gmail, Calendar, Sheets, Admin, and more) by parsing Google Discovery Documents at runtime. No generated crates or static API bindings are needed — when Google adds an endpoint, `gws` picks it up automatically.
+
+## Installation
+
+```bash
+npm install -g @googleworkspace/cli
+```
+
+The `gws` binary must be on `$PATH`.
+
+## Authentication
+
+```bash
+gws auth setup     # one-time: creates a Cloud project, enables APIs, logs in
+gws auth login     # subsequent logins with scope selection
+```
+
+For headless/CI:
+
+```bash
+export GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE=/path/to/credentials.json
+# or
+export GOOGLE_WORKSPACE_CLI_TOKEN=$(gcloud auth print-access-token)
+```
+
+## Core Syntax
+
+```bash
+gws <service> <resource> [sub-resource] <method> [flags]
+```
+
+Use `--help` at any level to discover available commands:
+
+```bash
+gws --help
+gws <service> --help
+gws <service> <resource> --help
+gws <service> <resource> <method> --help
+```
+
+## Key Flags
+
+| Flag | Description |
+|------|-------------|
+| `--params '<JSON>'` | URL/query parameters |
+| `--json '<JSON>'` | Request body for POST/PUT/PATCH |
+| `--fields '<MASK>'` | Limit response fields (critical for context efficiency) |
+| `--page-all` | Auto-paginate results as NDJSON |
+| `--page-limit <N>` | Max pages when using --page-all (default: 10) |
+| `--upload <PATH>` | Upload file content (multipart) |
+| `--output <PATH>` | Save binary responses to file |
+| `--dry-run` | Validate locally without calling the API |
+| `--sanitize <TEMPLATE>` | Screen responses through Model Armor |
+
+## Schema Introspection
+
+Before calling any API method, inspect its parameters and request body:
+
+```bash
+gws schema drive.files.list
+gws schema sheets.spreadsheets.create
+```
+
+## Common Patterns
+
+### Reading data (always use --fields to minimize output)
+
+```bash
+gws drive files list --params '{"pageSize": 10}' --fields "files(id,name,mimeType)"
+gws gmail users messages get --params '{"userId": "me", "id": "MSG_ID"}'
+gws calendar events list --params '{"calendarId": "primary", "maxResults": 5}'
+```
+
+### Writing data
+
+```bash
+gws sheets spreadsheets create --json '{"properties": {"title": "Q1 Budget"}}'
+gws calendar events insert --params '{"calendarId": "primary"}' --json '{"summary": "Team Sync", "start": {"dateTime": "2025-01-15T10:00:00Z"}, "end": {"dateTime": "2025-01-15T11:00:00Z"}}'
+```
+
+### Pagination
+
+```bash
+gws drive files list --params '{"pageSize": 100}' --page-all | jq -r '.files[].name'
+```
+
+### File uploads and downloads
+
+```bash
+gws drive files create --json '{"name": "report.pdf"}' --upload ./report.pdf
+gws drive files get --params '{"fileId": "FILE_ID", "alt": "media"}' --output ./downloaded.pdf
+```
+
+## Security Rules
+
+- Never output secrets (API keys, tokens) directly
+- Always confirm with the user before executing write/delete commands
+- Prefer `--dry-run` for destructive operations
+- Use `--sanitize` for PII/content safety screening
+
+## Available Services
+
+admin, admin-reports, alertcenter, apps-script, calendar, chat, classroom, cloudidentity, docs, drive, events, forms, gmail, groupssettings, keep, licensing, meet, modelarmor, people, reseller, sheets, slides, tasks, vault
+
+For the full list of service skills and recipes, see the `skills/` directory in the repository.

--- a/README.md
+++ b/README.md
@@ -263,6 +263,23 @@ The `gws-shared` skill includes an `install` block so OpenClaw auto-installs the
 
 </details>
 
+## Factory Droid
+
+The repo includes native [Factory Droid](https://docs.factory.ai/) integration via `.factory/skills/` and `.factory/droids/`. Once `gws` is authenticated, Factory Droid can use Google Workspace APIs directly through the bundled `gws` skill.
+
+1. Authenticate the CLI first:
+
+   ```bash
+   gws auth setup
+   ```
+
+2. The skill is automatically discovered when Droid runs inside this repository. To use the skill in other projects, copy the `.factory/skills/gws/` directory to your project's `.factory/skills/` folder:
+   ```bash
+   cp -r .factory/skills/gws /path/to/your/project/.factory/skills/
+   ```
+
+The `gws` skill teaches Droid the CLI syntax, authentication patterns, field masks, pagination, and safety rules. Droid will automatically invoke it when tasks involve Google Workspace resources.
+
 ## Gemini CLI Extension
 
 1. Authenticate the CLI first:


### PR DESCRIPTION
## Description

Adds native [Factory Droid](https://docs.factory.ai/) integration, following the same pattern as the existing Claude Code (`.claude/`), Gemini CLI Extension (`gemini-extension.json`), and `.agent/` integrations.

### What's included

- **`.factory/skills/gws/SKILL.md`** — A skill that teaches Factory Droid the `gws` CLI syntax, authentication patterns, field masks, pagination, and safety rules. Droid automatically invokes this skill when tasks involve Google Workspace resources.

- **`.factory/droids/gws-contributor.md`** — A project-scoped development droid that encodes the architecture (two-phase parsing, Discovery Documents), build commands (`cargo build/test/clippy`), input validation conventions, and changeset requirements. Contributors using Factory Droid get a subagent pre-loaded with project knowledge.

- **README section** — Documents the Factory Droid setup alongside the existing Gemini CLI Extension and OpenClaw sections.

- **Changeset** — Included as required by CI.

### How it works

Factory Droid discovers skills from `.factory/skills/` and droids from `.factory/droids/` automatically. No additional configuration is needed — users just need `gws` authenticated on their machine.

**Dry Run Output:** N/A (no CLI code changes)

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.