### PR TITLE
fix: use service alias in MCP tool names for aliased services

### DIFF
--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -243,7 +243,7 @@ async fn build_tools_list(config: &ServerConfig) -> Result<Vec<Value>, GwsError>
         let (api_name, version) =
             crate::parse_service_and_version(&[svc_name.to_string()], svc_name)?;
         if let Ok(doc) = crate::discovery::fetch_discovery_document(&api_name, &version).await {
-            walk_resources(&doc.name, &doc.resources, &mut tools);
+            walk_resources(svc_name, &doc.resources, &mut tools);
         } else {
             eprintln!("[gws mcp] Warning: Failed to load discovery document for service '{}'. It will not be available as a tool.", svc_name);
         }


### PR DESCRIPTION
## Summary
- Fixes #162
- `build_tools_list` used `doc.name` (the Discovery document's internal name) as the tool name prefix, but `handle_tools_call` validates against `config.services` which contains user-configured aliases
- Changed to use `svc_name` (the service alias) so listed tools match what the handler expects

## Test plan
- [ ] Configure an aliased service (e.g., `events` for workspaceevents)
- [ ] Run `tools/list` and verify tool names use the alias
- [ ] Call a tool and verify it resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)