### PR TITLE
fix: increase project timeout and add manual entry in gws auth setup (closes #116)

### DIFF
--- a/.changeset/fix-setup-project-timeout.md
+++ b/.changeset/fix-setup-project-timeout.md
@@ -1,0 +1,17 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Fix project timeout and add manual entry in `gws auth setup` (closes #116)
+
+Users who belong to organizations with thousands of GCP projects would hit
+the hardcoded 10-second timeout in `gws auth setup` when the CLI attempted
+to list their projects, blocking them from completing setup without manually
+using `--project`.
+
+This PR improves the experience for these users by:
+
+1. Increasing the project listing timeout from 10s to 30s to accommodate larger lists.
+2. Adding a new `✏️ Enter existing project ID` option to the interactive project picker.
+   If the user's project is missing due to API limits or dropouts, they can now manually type
+   the ID right from the setup menu.

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -546,7 +546,7 @@ fn list_gcloud_projects() -> (Vec<(String, String)>, Option<String>) {
     };
 
     // Wait with timeout
-    let timeout = std::time::Duration::from_secs(10);
+    let timeout = std::time::Duration::from_secs(30);
     let start = std::time::Instant::now();
     loop {
         match child.try_wait() {
@@ -587,7 +587,7 @@ fn list_gcloud_projects() -> (Vec<(String, String)>, Option<String>) {
                     let _ = child.kill();
                     return (
                         Vec::new(),
-                        Some("Timed out listing projects (10s)".to_string()),
+                        Some("Timed out listing projects (30s)".to_string()),
                     );
                 }
                 std::thread::sleep(std::time::Duration::from_millis(100));
@@ -989,14 +989,24 @@ fn stage_project(ctx: &mut SetupContext) -> Result<SetupStage, GwsError> {
         }
         let current = get_gcloud_project()?.unwrap_or_default();
 
-        let mut items: Vec<SelectItem> = vec![SelectItem {
-            label: "➕ Create new project".to_string(),
-            description: "Create a new GCP project for gws".to_string(),
-            selected: false,
-            is_fixed: false,
-            is_template: false,
-            template_selects: vec![],
-        }];
+        let mut items: Vec<SelectItem> = vec![
+            SelectItem {
+                label: "➕ Create new project".to_string(),
+                description: "Create a new GCP project for gws".to_string(),
+                selected: false,
+                is_fixed: false,
+                is_template: false,
+                template_selects: vec![],
+            },
+            SelectItem {
+                label: "✏️  Enter existing project ID".to_string(),
+                description: "Manually type a GCP project ID (useful if the list above is missing projects)".to_string(),
+                selected: false,
+                is_fixed: false,
+                is_template: false,
+                template_selects: vec![],
+            },
+        ];
         items.extend(projects.iter().map(|(id, name)| SelectItem {
             label: id.clone(),
             description: name.clone(),
@@ -1022,6 +1032,27 @@ fn stage_project(ctx: &mut SetupContext) -> Result<SetupStage, GwsError> {
             PickerResult::Confirmed(items) => {
                 let chosen = items.iter().find(|i| i.selected);
                 match chosen {
+                    Some(item) if item.label.starts_with("✏️") => {
+                        let project_id = match ctx
+                            .wizard
+                            .as_mut()
+                            .unwrap()
+                            .show_input("Enter GCP project", "Enter an existing project ID", None)
+                            .map_err(|e| GwsError::Validation(format!("TUI error: {e}")))?
+                        {
+                            crate::setup_tui::InputResult::Confirmed(v) if !v.is_empty() => v,
+                            _ => {
+                                return Err(GwsError::Validation(
+                                    "Project selection cancelled by user".to_string(),
+                                ))
+                            }
+                        };
+
+                        set_gcloud_project(&project_id)?;
+                        ctx.wiz(2, StepStatus::Done(project_id.clone()));
+                        ctx.project_id = project_id;
+                        Ok(SetupStage::EnableApis)
+                    }
                     Some(item) if item.label.starts_with('➕') => {
                         let project_name = match ctx
                             .wizard


### PR DESCRIPTION
Closes #116

…(closes #116)

Users who belong to organizations with thousands of GCP projects would hit the hardcoded 10-second timeout in gws auth setup when the CLI attempted to list their projects, blocking them from completing setup without manually using --project.

This PR improves the experience for these users by:
1. Increasing the project listing timeout from 10s to 30s
2. Adding a new '✏️ Enter existing project ID' option to the interactive project picker.

## Description

Please include a summary of the change and which issue is fixed. If adding a new feature or command, please include the output of running it with `--dry-run` to prove the JSON request body matches the Discovery Document schema.

**Dry Run Output:**
```json
// Paste --dry-run output here if applicable
```

## Checklist:

- [ ] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [ ] I have run `cargo fmt --all` to format the code perfectly.
- [ ] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.
