### PR TITLE
fix: use .zip for Windows npm installer to fix Git Bash install failure

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -36,6 +36,9 @@ pr-run-mode = "plan"
 # Don't overwrite release.yml on `cargo dist init` (preserves custom npm registry config)
 allow-dirty = ["ci"]
 # The archive format to use for windows builds (defaults .zip)
-windows-archive = ".tar.gz"
+# Using .zip routes through PowerShell's Expand-Archive, which correctly
+# handles Windows paths. Using .tar.gz causes failures in Git Bash because
+# MSYS tar interprets "C:" as a remote host (issue #152).
+windows-archive = ".zip"
 # The archive format to use for non-windows builds (defaults .tar.xz)
 unix-archive = ".tar.gz"


### PR DESCRIPTION
## Summary

Fixes #152 — `npm install -g @googleworkspace/cli` fails in Git Bash on Windows with:
```
tar: Cannot connect to C: resolve failed
```

## Root Cause

`dist-workspace.toml` configures `windows-archive = ".tar.gz"`, which routes the npm postinstall extraction through the system `tar` binary. In Git Bash on Windows, the bundled MSYS `tar` interprets `C:` in Windows file paths as a remote hostname, causing the extraction to fail.

The same command works fine in PowerShell because PowerShell uses Windows' built-in `tar.exe` which handles native paths correctly.

## Fix

Change `windows-archive` from `.tar.gz` to `.zip` (the default). The npm installer's `binary-install.js` already has a Windows-specific `.zip` code path that correctly uses PowerShell's `Expand-Archive`, which handles Windows paths properly in both PowerShell and Git Bash.

## Verified

Reproduced the original error in Git Bash on Windows 11, confirmed the `.zip` code path in `binary-install.js` already handles Windows extraction correctly via PowerShell.
