### PR TITLE
docs: clarify fields usage and UTF-8 subjects for gmail raw drafts

### DIFF
--- a/skills/gws-shared/SKILL.md
+++ b/skills/gws-shared/SKILL.md
@@ -51,23 +51,6 @@ gws <service> <resource> [sub-resource] <method> [flags]
 | `--page-limit <N>` | Max pages when using --page-all (default: 10) |
 | `--page-delay <MS>` | Delay between pages in ms (default: 100) |
 
-### Discovery API `fields`
-
-For Discovery API methods, pass partial-response selectors inside `--params`, not as a standalone `--fields` flag. Example:
-
-```bash
-gws drive files list --params '{"q":"trashed=false","fields":"files(id,name)"}'
-```
-
-### Gmail raw drafts with non-ASCII subjects
-
-When creating raw RFC 2822 Gmail drafts, encode non-ASCII `Subject` headers using RFC 2047 encoded-word format and use CRLF (`\r\n`) line endings:
-
-```bash
-SUBJECT_B64=$(printf '三月分享老師邀請' | base64 | tr -d '\n')
-RAW=$(printf "To: recipient@example.com\r\nSubject: =?UTF-8?B?%s?=\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nHello\r\n" "$SUBJECT_B64" | base64 | tr -d '\n' | tr '+/' '-_' | tr -d '=')
-```
-
 ## Security Rules
 
 - **Never** output secrets (API keys, tokens) directly


### PR DESCRIPTION
Fixes #266

Adds concise docs for two common pitfalls:
- response fields should be passed inside --params JSON
- non-ASCII Gmail raw subjects should use RFC 2047 encoded-word format

Also adds copy-paste examples in README troubleshooting/advanced usage.