### PR TITLE
fix: use native OS certificate store for TLS

### DIFF
--- a/.changeset/use-native-tls-roots.md
+++ b/.changeset/use-native-tls-roots.md
@@ -1,0 +1,8 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Switch reqwest TLS from bundled Mozilla roots to native OS certificate store
+
+This allows the CLI to trust custom or corporate CA certificates installed
+in the system trust store, fixing TLS errors in enterprise environments.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2019,6 +2018,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2035,7 +2035,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -3032,15 +3031,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ clap = { version = "4", features = ["derive", "string"] }
 dirs = "5"
 dotenvy = "0.15"
 hostname = "0.4"
-reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls-native-roots"], default-features = false }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## Summary

- Switch `reqwest` from `rustls-tls` feature (bundled Mozilla roots via `webpki-roots`) to `rustls-tls-native-roots` (OS native certificate store via `rustls-native-certs`)
- Removes `webpki-roots` dependency

## Motivation

In enterprise environments, organizations use internal/corporate certificate authorities. The bundled Mozilla root store does not include these, causing TLS handshake failures. Using the OS native trust store allows the CLI to respect any custom CA certificates installed by the user or their IT/admin team.

## Test plan

- [ ] All existing tests pass (`cargo test`)
- [ ] Verify CLI works in an environment with a corporate CA certificate installed in the system trust store

🤖 Generated with [Claude Code](https://claude.com/claude-code)