### PR TITLE
fix: use gmail.readonly scope in +triage to avoid metadata scope 403

### DIFF
--- a/.changeset/fix-gmail-triage-scope.md
+++ b/.changeset/fix-gmail-triage-scope.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Fix gmail +triage 403 error by using gmail.readonly scope instead of gmail.modify to avoid conflict with gmail.metadata scope that does not support the q parameter

--- a/src/helpers/gmail/mod.rs
+++ b/src/helpers/gmail/mod.rs
@@ -34,6 +34,7 @@ use std::pin::Pin;
 pub struct GmailHelper;
 
 pub(super) const GMAIL_SCOPE: &str = "https://www.googleapis.com/auth/gmail.modify";
+pub(super) const GMAIL_READONLY_SCOPE: &str = "https://www.googleapis.com/auth/gmail.readonly";
 pub(super) const PUBSUB_SCOPE: &str = "https://www.googleapis.com/auth/pubsub";
 
 impl Helper for GmailHelper {

--- a/src/helpers/gmail/triage.rs
+++ b/src/helpers/gmail/triage.rs
@@ -32,8 +32,12 @@ pub async fn handle_triage(matches: &ArgMatches) -> Result<(), GwsError> {
         .map(|s| crate::formatter::OutputFormat::from_str(s))
         .unwrap_or(crate::formatter::OutputFormat::Table);
 
-    // Authenticate
-    let token = auth::get_token(&[GMAIL_SCOPE])
+    // Authenticate — use gmail.readonly instead of gmail.modify because triage
+    // is read-only and the `q` query parameter is not supported under the
+    // gmail.metadata scope.  When a token carries both metadata and modify
+    // scopes the API may resolve to the metadata path and reject `q` with 403.
+    // gmail.readonly always supports `q`.
+    let token = auth::get_token(&[GMAIL_READONLY_SCOPE])
         .await
         .map_err(|e| GwsError::Auth(format!("Gmail auth failed: {e}")))?;
 


### PR DESCRIPTION
## Summary
- Fix `gmail +triage` failing with `403 PERMISSION_DENIED` when the OAuth token includes `gmail.metadata` scope alongside other Gmail scopes
- Switch the `+triage` helper from requesting `gmail.modify` to `gmail.readonly` scope, which supports the `q` query parameter and matches the read-only nature of triage
- Add `GMAIL_READONLY_SCOPE` constant for reuse by read-only Gmail helpers

## Root Cause
The `+triage` helper uses the `q` query parameter when calling `messages.list`, but Gmail's metadata scope does not support `q` and returns 403. When a user's OAuth token carries both `gmail.metadata` and `gmail.modify` scopes, the Gmail API may resolve to the metadata code path and reject the query with `PERMISSION_DENIED`.

## Test plan
- [x] `cargo clippy -- -D warnings` passes with no warnings
- [x] `cargo test` passes (429 tests)
- [ ] Manual: run `gws gmail +triage` with a token that has both `gmail.metadata` and `gmail.readonly` scopes -- should return unread inbox summary without 403

Fixes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)