### PR TITLE
fix: handle null libc version on Android/Termux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,6 +212,22 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
+      - name: Patch npm binary.js for libc detection
+        shell: bash
+        run: |
+          # Fix null libcVersion crash on Android/Termux (bionic libc)
+          # See: https://github.com/googleworkspace/cli/issues/271
+          NPM_TARBALL=$(find target/distrib -name '*-npm-package.tar.gz' | head -1)
+          if [ -n "$NPM_TARBALL" ]; then
+            WORK_DIR=$(mktemp -d)
+            tar xzf "$NPM_TARBALL" -C "$WORK_DIR"
+            cp npm/binary.js "$WORK_DIR/package/binary.js"
+            tar czf "$NPM_TARBALL" -C "$WORK_DIR" package
+            rm -rf "$WORK_DIR"
+            echo "Patched npm binary.js in $NPM_TARBALL"
+          else
+            echo "No npm tarball found, skipping patch"
+          fi
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v6
         with:

--- a/npm/binary.js
+++ b/npm/binary.js
@@ -1,0 +1,137 @@
+const { Package } = require("./binary-install");
+const os = require("os");
+const cTable = require("console.table");
+const libc = require("detect-libc");
+const { configureProxy } = require("axios-proxy-builder");
+
+const error = (msg) => {
+  console.error(msg);
+  process.exit(1);
+};
+
+const {
+  name,
+  artifactDownloadUrls,
+  supportedPlatforms,
+  glibcMinimum,
+} = require("./package.json");
+
+// FIXME: implement NPM installer handling of fallback download URLs
+const artifactDownloadUrl = artifactDownloadUrls[0];
+const builderGlibcMajorVersion = glibcMinimum.major;
+const builderGlibcMinorVersion = glibcMinimum.series;
+
+const getPlatform = () => {
+  const rawOsType = os.type();
+  const rawArchitecture = os.arch();
+
+  // We want to use rust-style target triples as the canonical key
+  // for a platform, so translate the "os" library's concepts into rust ones
+  let osType = "";
+  switch (rawOsType) {
+    case "Windows_NT":
+      osType = "pc-windows-msvc";
+      break;
+    case "Darwin":
+      osType = "apple-darwin";
+      break;
+    case "Linux":
+      osType = "unknown-linux-gnu";
+      break;
+  }
+
+  let arch = "";
+  switch (rawArchitecture) {
+    case "x64":
+      arch = "x86_64";
+      break;
+    case "arm64":
+      arch = "aarch64";
+      break;
+  }
+
+  if (rawOsType === "Linux") {
+    if (libc.familySync() == "musl") {
+      osType = "unknown-linux-musl-dynamic";
+    } else if (libc.isNonGlibcLinuxSync()) {
+      console.warn(
+        "Your libc is neither glibc nor musl; trying static musl binary instead",
+      );
+      osType = "unknown-linux-musl-static";
+    } else {
+      let libcVersion = libc.versionSync();
+      if (libcVersion == null) {
+        // detect-libc could not determine the libc version (e.g. Android/Termux
+        // with bionic libc). Fall back to static musl binary.
+        console.warn(
+          "Could not detect libc version; trying static musl binary instead",
+        );
+        osType = "unknown-linux-musl-static";
+      } else {
+        let splitLibcVersion = libcVersion.split(".");
+        let libcMajorVersion = splitLibcVersion[0];
+        let libcMinorVersion = splitLibcVersion[1];
+        if (
+          libcMajorVersion != builderGlibcMajorVersion ||
+          libcMinorVersion < builderGlibcMinorVersion
+        ) {
+          // We can't run the glibc binaries, but we can run the static musl ones
+          // if they exist
+          console.warn(
+            "Your glibc isn't compatible; trying static musl binary instead",
+          );
+          osType = "unknown-linux-musl-static";
+        }
+      }
+    }
+  }
+
+  // Assume the above succeeded and build a target triple to look things up with.
+  // If any of it failed, this lookup will fail and we'll handle it like normal.
+  let targetTriple = `${arch}-${osType}`;
+  let platform = supportedPlatforms[targetTriple];
+
+  if (!platform) {
+    error(
+      `Platform with type "${rawOsType}" and architecture "${rawArchitecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${Object.keys(
+        supportedPlatforms,
+      ).join(",")}`,
+    );
+  }
+
+  return platform;
+};
+
+const getPackage = () => {
+  const platform = getPlatform();
+  const url = `${artifactDownloadUrl}/${platform.artifactName}`;
+  let filename = platform.artifactName;
+  let ext = platform.zipExt;
+  let binary = new Package(platform, name, url, filename, ext, platform.bins);
+
+  return binary;
+};
+
+const install = (suppressLogs) => {
+  if (!artifactDownloadUrl || artifactDownloadUrl.length === 0) {
+    console.warn("in demo mode, not installing binaries");
+    return;
+  }
+  const package = getPackage();
+  const proxy = configureProxy(package.url);
+
+  return package.install(proxy, suppressLogs);
+};
+
+const run = (binaryName) => {
+  const package = getPackage();
+  const proxy = configureProxy(package.url);
+
+  package.run(binaryName, proxy);
+};
+
+module.exports = {
+  install,
+  run,
+  getPackage,
+};


### PR DESCRIPTION
## Summary
- Fixes crash on Android/Termux where `detect-libc` returns `null` for the libc version (bionic libc), causing `binary.js` to throw `TypeError: Cannot read properties of null (reading 'split')`
- Adds a null check for `libcVersion` in the npm installer's `binary.js`, falling back to the static musl binary when the libc version cannot be detected
- Patches the cargo-dist-generated npm package during the release build via a new workflow step

## Details
On Android/Termux with bionic libc:
1. `libc.familySync()` does not return `"musl"`
2. `libc.isNonGlibcLinuxSync()` returns `false`
3. `libc.versionSync()` returns `null`
4. Calling `.split(".")` on `null` crashes the CLI

The fix adds a null guard before the `.split()` call. When `libcVersion` is `null`, the installer logs a warning and falls back to the static musl binary, matching the existing behavior for other incompatible libc scenarios.

Since `binary.js` is generated by cargo-dist, the patched version is stored in `npm/binary.js` and applied to the npm tarball during the `build-global-artifacts` step of the release workflow.

Fixes #271

## Test plan
- [x] All existing Rust tests pass (426 tests)
- [x] `binary.js` passes Node.js syntax check (`node --check`)
- [ ] Verify on Android/Termux that `gws` no longer crashes with null libc version

🤖 Generated with [Claude Code](https://claude.com/claude-code)