### PR TITLE
feat: add Google Search Console as a known service

### DIFF
--- a/.changeset/add-searchconsole.md
+++ b/.changeset/add-searchconsole.md
@@ -1,0 +1,8 @@
+---
+"@googleworkspace/cli": minor
+---
+
+Add Google Search Console (`searchconsole` v1) as a known service.
+
+Enables `gws searchconsole sites list`, `gws searchconsole searchAnalytics query`, etc.
+The Search Console API has a valid Discovery document and works with the existing dynamic command/tool generation.

--- a/src/services.rs
+++ b/src/services.rs
@@ -121,6 +121,12 @@ pub const SERVICES: &[ServiceEntry] = &[
         description: "Filter user-generated content for safety",
     },
     ServiceEntry {
+        aliases: &["searchconsole"],
+        api_name: "searchconsole",
+        version: "v1",
+        description: "Search performance, URL inspection, and sitemaps",
+    },
+    ServiceEntry {
         aliases: &["workflow", "wf"],
         api_name: "workflow",
         version: "v1",
@@ -164,6 +170,13 @@ mod tests {
             resolve_service("reports").unwrap(),
             ("admin".to_string(), "reports_v1".to_string())
         );
+    }
+
+    #[test]
+    fn test_resolve_service_searchconsole() {
+        let (api_name, version) = resolve_service("searchconsole").unwrap();
+        assert_eq!(api_name, "searchconsole");
+        assert_eq!(version, "v1");
     }
 
     #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -170,6 +170,12 @@ const WORKSPACE_APIS: &[ApiEntry] = &[
         discovery: "pubsub",
         version: "v1",
     },
+    ApiEntry {
+        id: "searchconsole.googleapis.com",
+        name: "Search Console",
+        discovery: "searchconsole",
+        version: "v1",
+    },
 ];
 
 const RESTRICTED_SCOPES: &[&str] = &[


### PR DESCRIPTION
## Summary

- Registers `searchconsole` v1 in `src/services.rs` SERVICES array so `gws searchconsole <resource> <method>` works
- Adds corresponding `searchconsole.googleapis.com` entry to `WORKSPACE_APIS` in `src/setup.rs` for `gws auth setup` API enablement
- Includes unit test `test_resolve_service_searchconsole`

## Motivation

Google Search Console has a valid [Discovery document](https://www.googleapis.com/discovery/v1/apis/searchconsole/v1/rest) and works with gws dynamic command generation. Adding it as a known service enables commands like:

```bash
gws searchconsole sites list
gws searchconsole searchAnalytics query --json '{...}'
gws searchconsole urlInspection index inspect
gws searchconsole sitemaps list --params '{"siteUrl":"https://example.com"}'
```

The deprecated `webmasters` v3 API returns 404 from Discovery — `searchconsole` v1 is the correct identifier.

## Dry-run output

Not available without OAuth credentials configured for a verified Search Console property. The Discovery document is confirmed valid (fetches and parses successfully).

## Test plan

- [x] `cargo test test_resolve_service_searchconsole` — passes
- [x] `cargo test` — all 430 tests pass (including `test_workspace_api_ids_covers_services`)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Changeset included (`.changeset/add-searchconsole.md`, `minor`)

## Checklist

- [x] Tests added
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Changeset added