### PR TITLE
build(ci): optimize nix and windows cache layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   changes:
@@ -82,9 +84,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Check flake
         run: nix flake check
       - name: Build flake
@@ -183,6 +186,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: build-${{ matrix.target }}
+          cache-targets: "false"
 
       - name: Install cross-compilation tools
         if: matrix.target == 'aarch64-unknown-linux-gnu'


### PR DESCRIPTION
Implements Zero-Configuration caching for Nix builds using DeterminateSystems/magic-nix-cache-action and properly activates sccache for Windows builds by setting the RUSTC_WRAPPER.