### PR TITLE
fix(ci): add missing tool input to install-action for cargo-llvm-cov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,6 +40,8 @@ jobs:
           
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@a37010ded18ff788be4440302bd6830b1ae50d8b # cargo-llvm-cov
+        with:
+          tool: cargo-llvm-cov
         
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info


### PR DESCRIPTION
## Root Cause

PR #341 ("ci: pin all actions to a sha") changed:
```yaml
# Before — tool name passed as the tag
uses: taiki-e/install-action@cargo-llvm-cov

# After — SHA pin, tool name lost
uses: taiki-e/install-action@a37010d...
```

`taiki-e/install-action` uses the Git ref (tag) to determine which tool to install. When pinned to a SHA, the tag context is gone, so the action warns *"no tool specified"* and installs nothing. Every Coverage run since #341 was merged has been failing.

## Fix

Add the explicit `tool` input:
```yaml
uses: taiki-e/install-action@a37010d...
with:
  tool: cargo-llvm-cov
```

## When It Broke

Commit `d5d77d9` merged on 2026-03-09T13:52:49-06:00. All coverage runs since then have failed.