### PR TITLE
ci: run smoketest immediately after linux build, gate other builds on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,16 +189,60 @@ jobs:
             echo "::warning::Skills are out of date — the hourly auto-sync PR will fix this automatically."
           fi
 
-  build:
-    name: Build
+  build-linux:
+    name: Build (Linux x86_64)
     needs: changes
     if: needs.changes.outputs.rust == 'true' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Setup sccache
+        id: sccache
+        uses: mozilla-actions/sccache-action@2df7dbab909c49ab7d3382d05da469f3f975c2d6 # v0.0.7
+        continue-on-error: true
+
+      - name: Enable sccache
+        if: steps.sccache.outcome == 'success'
+        shell: bash
+        run: |
+          if sccache --start-server 2>/dev/null; then
+            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          else
+            echo "::warning::sccache server failed to start, building without cache"
+          fi
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db # v2
+        with:
+          key: build-x86_64-unknown-linux-gnu
+          cache-targets: "false"
+
+      - name: Build
+        run: cargo build --release --target x86_64-unknown-linux-gnu
+
+      - name: Upload binary
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: gws-linux-x86_64
+          path: target/x86_64-unknown-linux-gnu/release/gws
+          retention-days: 1
+
+  build:
+    name: Build
+    needs: [smoketest, changes]
+    if: |
+      always() && !cancelled() && !failure()
+      && (needs.changes.outputs.rust == 'true' || github.event_name == 'push')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
           - os: macos-latest
@@ -254,17 +298,9 @@ jobs:
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
-      - name: Upload binary
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: gws-linux-x86_64
-          path: target/x86_64-unknown-linux-gnu/release/gws
-          retention-days: 1
-
   smoketest:
     name: API Smoketest
-    needs: build
+    needs: build-linux
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Split x86_64-unknown-linux-gnu out of the build matrix into a dedicated
build-linux job. The smoketest now depends only on build-linux, running
as soon as that single build completes. The remaining cross-platform
builds (macOS, Windows, aarch64-linux) depend on the smoketest, so they
are skipped entirely if the smoketest fails — saving CI minutes.
