### PR TITLE
fix(gmail): bring +forward behavior in line with Gmail web UI

### DIFF
--- a/.changeset/fix-forward-threading.md
+++ b/.changeset/fix-forward-threading.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Bring `+forward` behavior in line with Gmail's web UI: keep the forward in the sender's original thread, add a blank line between the forwarded message metadata and body, and remove the spurious closing delimiter.

--- a/skills/gws-gmail-forward/SKILL.md
+++ b/skills/gws-gmail-forward/SKILL.md
@@ -44,7 +44,6 @@ gws gmail +forward --message-id 18f1a2b3c4d --to dave@example.com --cc eve@examp
 ## Tips
 
 - Includes the original message with sender, date, subject, and recipients.
-- Sends the forward as a new message rather than forcing it into the original thread.
 
 ## See Also
 

--- a/src/helpers/gmail/forward.rs
+++ b/src/helpers/gmail/forward.rs
@@ -46,7 +46,14 @@ pub(super) async fn handle_forward(
         &original,
     );
 
-    super::send_raw_email(doc, matches, &raw, None, token.as_deref()).await
+    super::send_raw_email(
+        doc,
+        matches,
+        &raw,
+        Some(&original.thread_id),
+        token.as_deref(),
+    )
+    .await
 }
 
 pub(super) struct ForwardConfig {
@@ -73,9 +80,16 @@ fn create_forward_raw_message(
     body: Option<&str>,
     original: &OriginalMessage,
 ) -> String {
+    let references = if original.references.is_empty() {
+        original.message_id_header.clone()
+    } else {
+        format!("{} {}", original.references, original.message_id_header)
+    };
+
     let mut headers = format!(
-        "To: {}\r\nSubject: {}\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8",
-        to, subject
+        "To: {}\r\nSubject: {}\r\nIn-Reply-To: {}\r\nReferences: {}\r\n\
+         MIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8",
+        to, subject, original.message_id_header, references
     );
 
     if let Some(from) = from {
@@ -101,8 +115,8 @@ fn format_forwarded_message(original: &OriginalMessage) -> String {
          Date: {}\r\n\
          Subject: {}\r\n\
          To: {}\r\n\
-         {}{}\r\n\
-         ----------",
+         {}\r\n\
+         {}",
         original.from,
         original.date,
         original.subject,
@@ -171,9 +185,14 @@ mod tests {
 
         assert!(raw.contains("To: dave@example.com"));
         assert!(raw.contains("Subject: Fwd: Hello"));
+        assert!(raw.contains("In-Reply-To: <abc@example.com>"));
+        assert!(raw.contains("References: <abc@example.com>"));
         assert!(raw.contains("---------- Forwarded message ---------"));
         assert!(raw.contains("From: alice@example.com"));
-        assert!(raw.contains("Original content"));
+        // Blank line separates metadata block from body
+        assert!(raw.contains("To: bob@example.com\r\n\r\nOriginal content"));
+        // No closing ---------- delimiter
+        assert!(!raw.ends_with("----------"));
     }
 
     #[test]
@@ -203,6 +222,36 @@ mod tests {
         assert!(raw.contains("Cc: eve@example.com"));
         assert!(raw.contains("FYI see below"));
         assert!(raw.contains("Cc: carol@example.com"));
+    }
+
+    #[test]
+    fn test_create_forward_raw_message_references_chain() {
+        let original = super::super::OriginalMessage {
+            thread_id: "t1".to_string(),
+            message_id_header: "<msg-2@example.com>".to_string(),
+            references: "<msg-0@example.com> <msg-1@example.com>".to_string(),
+            from: "alice@example.com".to_string(),
+            reply_to: "".to_string(),
+            to: "bob@example.com".to_string(),
+            cc: "".to_string(),
+            subject: "Hello".to_string(),
+            date: "Mon, 1 Jan 2026 00:00:00 +0000".to_string(),
+            body_text: "Original content".to_string(),
+        };
+
+        let raw = create_forward_raw_message(
+            "dave@example.com",
+            None,
+            None,
+            "Fwd: Hello",
+            None,
+            &original,
+        );
+
+        assert!(raw.contains("In-Reply-To: <msg-2@example.com>"));
+        assert!(
+            raw.contains("References: <msg-0@example.com> <msg-1@example.com> <msg-2@example.com>")
+        );
     }
 
     fn make_forward_matches(args: &[&str]) -> ArgMatches {


### PR DESCRIPTION
## Description

The `+forward` helper (added in #105) sends forwards as new threads, which doesn't match Gmail's web UI behavior. When you forward from Gmail, the forward stays in the sender's original conversation thread. This PR fixes that and cleans up the forwarded message formatting.

**Threading fix:**
- Pass the original `threadId` to `send_raw_email` (matching what `+reply` already does)
- Add `In-Reply-To` and `References` headers for RFC 5322 compliance — required by the Gmail API for thread placement alongside `threadId`

**Formatting fixes:**
- Add blank line between the forwarded message metadata block and body (was missing, causing the body to run into the `To:`/`Cc:` line)
- Remove spurious closing `----------` delimiter that Gmail doesn't produce

**SKILL.md:**
- Remove tip that said forwards are sent as new messages

Related: #88

**Dry Run Output:**

```bash
$ gws gmail +forward --message-id 18f1a2b3c4d --to dave@example.com --body 'FYI see below' --dry-run
```

```json
{
  "body": {
    "raw": "VG86IGRhdmVAZXhhbXBsZS5jb20NClN1YmplY3Q6...<truncated>",
    "threadId": "thread-18f1a2b3c4d"
  },
  "dry_run": true,
  "is_multipart_upload": false,
  "method": "POST",
  "query_params": {},
  "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages/send"
}
```

Decoded `raw` (base64 → plaintext):
```
To: dave@example.com
Subject: Fwd: Original subject
In-Reply-To: <18f1a2b3c4d@example.com>
References: <18f1a2b3c4d@example.com>
MIME-Version: 1.0
Content-Type: text/plain; charset=utf-8

FYI see below

---------- Forwarded message ---------
From: sender@example.com
Date: Thu, 1 Jan 2026 00:00:00 +0000
Subject: Original subject
To: you@example.com

Original message body
```

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.