### PR TITLE
docs(auth export): documment --unmasked flag

### DIFF
--- a/.changeset/tame-rabbits-yawn.md
+++ b/.changeset/tame-rabbits-yawn.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Document `unmasked` flag for `gws auth export`

--- a/src/auth_commands.rs
+++ b/src/auth_commands.rs
@@ -398,7 +398,7 @@ async fn fetch_userinfo_email(access_token: &str) -> Option<String> {
         .map(|s| s.to_string())
 }
 
-/// Export credentials to stdout 
+/// Export credentials to stdout
 async fn handle_export(unmasked: bool) -> Result<(), GwsError> {
     let enc_path = credential_store::encrypted_credentials_path();
     if !enc_path.exists() {


### PR DESCRIPTION
## Description

Document `--unmasked` flag for `gws auth export` 

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.
