### PR TITLE
fix(auth): verify keyring roundtrip before deleting .encryption_key

### DIFF
--- a/src/credential_store.rs
+++ b/src/credential_store.rs
@@ -89,11 +89,9 @@ fn get_or_create_key() -> anyhow::Result<[u8; 32]> {
                     if decoded.len() == 32 {
                         let mut arr = [0u8; 32];
                         arr.copy_from_slice(&decoded);
-                        // Keyring is authoritative — remove redundant file copy
-                        // if it exists (migrates existing installs on upgrade).
-                        if key_file.exists() {
-                            let _ = std::fs::remove_file(&key_file);
-                        }
+                        // Keyring read succeeded — keep the file as a backup
+                        // in case a future process cannot access the keyring
+                        // (e.g. ad-hoc signed binaries on macOS).
                         return Ok(cache_key(arr));
                     }
                 }
@@ -108,10 +106,25 @@ fn get_or_create_key() -> anyhow::Result<[u8; 32]> {
                             if decoded.len() == 32 {
                                 let mut arr = [0u8; 32];
                                 arr.copy_from_slice(&decoded);
-                                // Migrate file key into keyring; remove the
-                                // file if the keyring store succeeds.
+                                // Try to migrate file key into keyring, but
+                                // only remove the file if we can verify the
+                                // roundtrip (read back what we just wrote).
                                 if entry.set_password(b64_key.trim()).is_ok() {
-                                    let _ = std::fs::remove_file(&key_file);
+                                    match entry.get_password() {
+                                        Ok(readback) if readback.trim() == b64_key.trim() => {
+                                            // Keyring roundtrip verified — safe
+                                            // to remove the file copy.
+                                            let _ = std::fs::remove_file(&key_file);
+                                        }
+                                        _ => {
+                                            // Keyring write appeared to succeed
+                                            // but readback failed — keep the file.
+                                            eprintln!(
+                                                "Warning: OS keyring write succeeded but readback \
+                                                 failed; keeping .encryption_key file as fallback."
+                                            );
+                                        }
+                                    }
                                 }
                                 return Ok(cache_key(arr));
                             }
@@ -124,14 +137,11 @@ fn get_or_create_key() -> anyhow::Result<[u8; 32]> {
                 rand::thread_rng().fill_bytes(&mut key);
                 let b64_key = STANDARD.encode(key);
 
-                // Try keyring first; only fall back to file storage
-                // if the keyring is unavailable.
-                if entry.set_password(&b64_key).is_ok() {
-                    return Ok(cache_key(key));
-                }
-
-                // Keyring store failed — persist to local file as fallback.
+                // Always persist to local file first so the key is never lost.
                 save_key_file(&key_file, &b64_key)?;
+
+                // Also try to store in keyring for convenience.
+                let _ = entry.set_password(&b64_key);
 
                 return Ok(cache_key(key));
             }


### PR DESCRIPTION
## Summary

Fixes the credential decryption bug that makes `gws` unusable on macOS (and some Linux environments) after `gws auth login`.

- **Root cause**: `get_or_create_key()` in `credential_store.rs` deletes the `.encryption_key` file after `entry.set_password()` returns `Ok(())`. On macOS with ad-hoc signed binaries (e.g. npm-installed), the Keychain write silently fails to persist — so the next process invocation can't read the key back, generates a new random key, and existing `credentials.enc` becomes permanently undecryptable.
- **Symptom**: `"encryption_error": "Could not decrypt. May have been created on a different machine."` immediately after a successful `gws auth login`, on the same machine.

## Changes

1. **Migration path** (existing file key → keyring): After `set_password()`, verify the roundtrip with `get_password()`. Only delete `.encryption_key` if readback matches.
2. **New key generation**: Always write to the local `.encryption_key` file first (source of truth), then optionally store in keyring. Previously it wrote to keyring only and skipped the file if `set_password()` returned `Ok`.
3. **Keyring-read-success path**: Stop proactively deleting the `.encryption_key` file when keyring read succeeds — keep it as a durable backup for environments where keyring access is intermittent.

## Test plan

- [x] `cargo check` passes
- [x] On macOS (Apple Silicon, npm install): `gws auth login` → `gws auth status` shows `encryption_valid: true`
- [x] On macOS: `.encryption_key` file is preserved after login
- [ ] On Linux with no keyring daemon: same flow works via file fallback
- [ ] Existing unit tests pass (`encrypt_decrypt_round_trip`, etc.)

## Fixes

Closes #360, #364, #367, #375, #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)