### PR TITLE
ci: use bot token for /gemini review comment

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Trigger Gemini Code Assist review
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GOOGLEWORKSPACE_BOT_TOKEN }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
Gemini Code Assist ignores `/gemini review` comments from `github-actions[bot]`. Switching to `GOOGLEWORKSPACE_BOT_TOKEN` so the comment is posted as `googleworkspace-bot`, which Gemini Code Assist responds to.

Since this uses `pull_request_target`, the secret is available even on fork PRs.