### PR TITLE
fix(ci): check remote tags in tag-release.sh

### DIFF
--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 VERSION=$(node -p "require('./package.json').version")
 TAG="v${VERSION}"
 
-if git rev-parse "$TAG" >/dev/null 2>&1; then
+if git rev-parse "$TAG" >/dev/null 2>&1 || git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
   echo "Tag $TAG already exists, skipping"
   exit 0
 fi


### PR DESCRIPTION
The idempotency guard in `tag-release.sh` only checked local tags via `git rev-parse`, but CI checkouts don't fetch tags by default. This caused the Release workflow to fail when re-running on a version that was already tagged.

Adds a `git ls-remote --exit-code --tags` fallback so re-runs gracefully skip already-pushed tags.

Fixes the failure in https://github.com/googleworkspace/cli/actions/runs/22920348826/job/66516758216