### PR TITLE
docs(skills): add COOKBOOK.md for gws-docs with tab and formatting recipes

### DIFF
--- a/skills/gws-docs/COOKBOOK.md
+++ b/skills/gws-docs/COOKBOOK.md
@@ -147,7 +147,7 @@ gws docs documents batchUpdate \
   }'
 ```
 
-Replace `"bold": true` with `"italic": true` for italic, or combine both with `"fields": "bold,italic"`.
+Replace `"bold": true` with `"italic": true` for italic, or combine both by setting `"textStyle": {"bold": true, "italic": true}` and `"fields": "bold,italic"`.
 
 ### Tips for batch formatting
 


### PR DESCRIPTION
## Summary

- Adds a `COOKBOOK.md` file alongside the auto-generated `SKILL.md` in `skills/gws-docs/`
- Documents non-obvious Google Docs API patterns that are hard to discover from `gws schema` output alone
- Establishes a pattern other skills can adopt for hand-written recipes

## Motivation

`SKILL.md` files are auto-generated by `gws generate-skills` and list API methods. However, some services have usage patterns that require trial-and-error to discover:

- **Tab operations**: `addDocumentTab` (not `createTab`), `includeTabsContent` for reading, `tabId` in `location`/`range` objects
- **Formatted content**: the insert-then-style pattern with `insertText` + `updateParagraphStyle`
- **`+write` limitations**: no tab targeting, plain text only

By placing recipes in a separate `COOKBOOK.md`, they survive `gws generate-skills` regeneration while remaining co-located and discoverable.

## What's included

| Section | Recipes |
|---------|---------|
| Working with Tabs | Read, create, write to, rename, delete tabs |
| Formatted Content | Insert-then-style pattern, heading styles, bold/italic |
| Request Types | Complete reference table of valid `batchUpdate` requests |
| `+write` Limitations | Workarounds for tab and formatting gaps |

## Test plan

- [ ] Verify `gws generate-skills` does not overwrite or conflict with `COOKBOOK.md`
- [ ] Verify recipes work against a live Google Doc with multiple tabs

Closes #420