### PR TITLE
feat: add HTTP proxy support via environment variables

### DIFF
--- a/.changeset/proxy-support-review-fixes.md
+++ b/.changeset/proxy-support-review-fixes.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Improve proxy-aware OAuth flows and clean up review feedback for auth login.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ clap = { version = "4", features = ["derive", "string"] }
 dirs = "5"
 dotenvy = "0.15"
 hostname = "0.4"
-reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls-native-roots", "socks"] }
+reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls-native-roots", "socks"], default-features = false }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -25,6 +25,15 @@ use serde::Deserialize;
 
 use crate::credential_store;
 
+const PROXY_ENV_VARS: &[&str] = &[
+    "http_proxy",
+    "HTTP_PROXY",
+    "https_proxy",
+    "HTTPS_PROXY",
+    "all_proxy",
+    "ALL_PROXY",
+];
+
 /// Response from Google's token endpoint
 #[derive(Debug, Deserialize)]
 struct TokenResponse {
@@ -59,7 +68,7 @@ async fn refresh_token_with_reqwest(
 
     if !response.status().is_success() {
         let status = response.status();
-        let body = response.text().await.unwrap_or_default();
+        let body = response_text_or_placeholder(response.text().await);
         anyhow::bail!("Token refresh failed with status {}: {}", status, body);
     }
 
@@ -221,13 +230,14 @@ pub async fn get_token(scopes: &[&str]) -> anyhow::Result<String> {
 }
 
 /// Check if HTTP proxy environment variables are set
-fn has_proxy_env() -> bool {
-    std::env::var("http_proxy").is_ok()
-        || std::env::var("HTTP_PROXY").is_ok()
-        || std::env::var("https_proxy").is_ok()
-        || std::env::var("HTTPS_PROXY").is_ok()
-        || std::env::var("all_proxy").is_ok()
-        || std::env::var("ALL_PROXY").is_ok()
+pub(crate) fn has_proxy_env() -> bool {
+    PROXY_ENV_VARS
+        .iter()
+        .any(|key| std::env::var_os(key).is_some_and(|value| !value.is_empty()))
+}
+
+pub(crate) fn response_text_or_placeholder<E>(result: Result<String, E>) -> String {
+    result.unwrap_or_else(|_| "(could not read error response body)".to_string())
 }
 
 async fn get_token_inner(
@@ -465,6 +475,43 @@ mod tests {
                 None => std::env::remove_var(&self.name),
             }
         }
+    }
+
+    fn clear_proxy_env() -> Vec<EnvVarGuard> {
+        PROXY_ENV_VARS
+            .iter()
+            .map(|key| EnvVarGuard::remove(key))
+            .collect()
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn has_proxy_env_returns_false_when_unset() {
+        let _guards = clear_proxy_env();
+        assert!(!has_proxy_env());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn has_proxy_env_returns_true_when_set() {
+        let mut guards = clear_proxy_env();
+        guards.push(EnvVarGuard::set(
+            "HTTPS_PROXY",
+            "http://proxy.internal:8080",
+        ));
+        assert!(has_proxy_env());
+    }
+
+    #[test]
+    fn response_text_or_placeholder_returns_body() {
+        let body = response_text_or_placeholder(Result::<String, ()>::Ok("error body".to_string()));
+        assert_eq!(body, "error body");
+    }
+
+    #[test]
+    fn response_text_or_placeholder_returns_placeholder_on_error() {
+        let body = response_text_or_placeholder(Result::<String, ()>::Err(()));
+        assert_eq!(body, "(could not read error response body)");
     }
 
     #[tokio::test]

--- a/src/auth_commands.rs
+++ b/src/auth_commands.rs
@@ -15,23 +15,13 @@
 use std::collections::HashSet;
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpListener;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 use serde_json::json;
 
 use crate::credential_store;
 use crate::error::GwsError;
-
-/// Check if HTTP proxy environment variables are set
-fn has_proxy_env() -> bool {
-    std::env::var("http_proxy").is_ok()
-        || std::env::var("HTTP_PROXY").is_ok()
-        || std::env::var("https_proxy").is_ok()
-        || std::env::var("HTTPS_PROXY").is_ok()
-        || std::env::var("all_proxy").is_ok()
-        || std::env::var("ALL_PROXY").is_ok()
-}
 
 /// Response from Google's token endpoint
 #[derive(Debug, Deserialize)]
@@ -69,7 +59,7 @@ async fn exchange_code_with_reqwest(
 
     if !response.status().is_success() {
         let status = response.status();
-        let body = response.text().await.unwrap_or_default();
+        let body = crate::auth::response_text_or_placeholder(response.text().await);
         return Err(GwsError::Auth(format!(
             "Token exchange failed with status {}: {}",
             status, body
@@ -82,6 +72,43 @@ async fn exchange_code_with_reqwest(
         .map_err(|e| GwsError::Auth(format!("Failed to parse token response: {e}")))
 }
 
+fn build_proxy_auth_url(client_id: &str, redirect_uri: &str, scopes: &[String]) -> String {
+    let scopes_str = scopes.join(" ");
+    format!(
+        "https://accounts.google.com/o/oauth2/auth?\
+         scope={}&\
+         access_type=offline&\
+         redirect_uri={}&\
+         response_type=code&\
+         client_id={}&\
+         prompt=select_account+consent",
+        urlencoding(&scopes_str),
+        urlencoding(redirect_uri),
+        urlencoding(client_id)
+    )
+}
+
+fn extract_authorization_code(request_line: &str) -> Result<String, GwsError> {
+    let path = request_line
+        .split_whitespace()
+        .nth(1)
+        .ok_or_else(|| GwsError::Auth("Invalid HTTP request".to_string()))?;
+
+    path.split('?')
+        .nth(1)
+        .and_then(|query| {
+            query.split('&').find_map(|pair| {
+                let mut parts = pair.split('=');
+                if parts.next() == Some("code") {
+                    parts.next().map(|value| value.to_string())
+                } else {
+                    None
+                }
+            })
+        })
+        .ok_or_else(|| GwsError::Auth("No authorization code in callback".to_string()))
+}
+
 /// Perform OAuth login flow with proxy support using reqwest for token exchange
 async fn login_with_proxy_support(
     client_id: &str,
@@ -91,23 +118,13 @@ async fn login_with_proxy_support(
     // Start local server to receive OAuth callback
     let listener = TcpListener::bind("127.0.0.1:0")
         .map_err(|e| GwsError::Auth(format!("Failed to start local server: {e}")))?;
-    let port = listener.local_addr().unwrap().port();
+    let port = listener
+        .local_addr()
+        .map_err(|e| GwsError::Auth(format!("Failed to inspect local server: {e}")))?
+        .port();
     let redirect_uri = format!("http://localhost:{}", port);
 
-    // Build OAuth URL
-    let scopes_str = scopes.join(" ");
-    let auth_url = format!(
-        "https://accounts.google.com/o/oauth2/auth?\
-         scope={}&\
-         access_type=offline&\
-         redirect_uri={}&\
-         response_type=code&\
-         client_id={}&\
-         prompt=select_account+consent",
-        urlencoding(&scopes_str),
-        urlencoding(&redirect_uri),
-        urlencoding(client_id)
-    );
+    let auth_url = build_proxy_auth_url(client_id, &redirect_uri, scopes);
 
     println!("Open this URL in your browser to authenticate:\n");
     println!("  {}\n", auth_url);
@@ -123,26 +140,7 @@ async fn login_with_proxy_support(
         .read_line(&mut request_line)
         .map_err(|e| GwsError::Auth(format!("Failed to read request: {e}")))?;
 
-    // Extract code from URL: GET /?code=XXX&... HTTP/1.1
-    let path = request_line
-        .split_whitespace()
-        .nth(1)
-        .ok_or_else(|| GwsError::Auth("Invalid HTTP request".to_string()))?;
-
-    let code = path
-        .split('?')
-        .nth(1)
-        .and_then(|query| {
-            query.split('&').find_map(|pair| {
-                let mut parts = pair.split('=');
-                if parts.next() == Some("code") {
-                    parts.next().map(|v| v.to_string())
-                } else {
-                    None
-                }
-            })
-        })
-        .ok_or_else(|| GwsError::Auth("No authorization code in callback".to_string()))?;
+    let code = extract_authorization_code(&request_line)?;
 
     // Send success response to browser
     let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n\
@@ -150,13 +148,86 @@ async fn login_with_proxy_support(
     let _ = stream.write_all(response.as_bytes());
 
     // Exchange code for tokens using reqwest (proxy-aware)
-    let token_response = exchange_code_with_reqwest(client_id, client_secret, &code, &redirect_uri).await?;
+    let token_response =
+        exchange_code_with_reqwest(client_id, client_secret, &code, &redirect_uri).await?;
 
-    let refresh_token = token_response
-        .refresh_token
-        .ok_or_else(|| GwsError::Auth("No refresh token returned".to_string()))?;
+    let refresh_token = token_response.refresh_token.ok_or_else(|| {
+        GwsError::Auth(
+            "OAuth flow completed but no refresh token was returned. \
+                 Ensure the OAuth consent screen includes 'offline' access."
+                .to_string(),
+        )
+    })?;
 
     Ok((token_response.access_token, refresh_token))
+}
+
+fn read_refresh_token_from_cache(temp_path: &Path) -> Result<String, GwsError> {
+    let token_data = std::fs::read(temp_path)
+        .ok()
+        .and_then(|bytes| crate::credential_store::decrypt(&bytes).ok())
+        .and_then(|decrypted| String::from_utf8(decrypted).ok())
+        .unwrap_or_default();
+
+    extract_refresh_token(&token_data).ok_or_else(|| {
+        GwsError::Auth(
+            "OAuth flow completed but no refresh token was returned. \
+             Ensure the OAuth consent screen includes 'offline' access."
+                .to_string(),
+        )
+    })
+}
+
+async fn login_with_yup_oauth(
+    config_dir: &Path,
+    client_id: &str,
+    client_secret: &str,
+    scopes: &[String],
+) -> Result<(String, String), GwsError> {
+    let secret = yup_oauth2::ApplicationSecret {
+        client_id: client_id.to_string(),
+        client_secret: client_secret.to_string(),
+        auth_uri: "https://accounts.google.com/o/oauth2/auth".to_string(),
+        token_uri: "https://oauth2.googleapis.com/token".to_string(),
+        redirect_uris: vec!["http://localhost".to_string()],
+        ..Default::default()
+    };
+
+    let temp_path = config_dir.join("credentials.tmp");
+    let _ = std::fs::remove_file(&temp_path);
+
+    let result = async {
+        let auth = yup_oauth2::InstalledFlowAuthenticator::builder(
+            secret,
+            yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
+        )
+        .with_storage(Box::new(crate::token_storage::EncryptedTokenStorage::new(
+            temp_path.clone(),
+        )))
+        .force_account_selection(true)
+        .flow_delegate(Box::new(CliFlowDelegate { login_hint: None }))
+        .build()
+        .await
+        .map_err(|e| GwsError::Auth(format!("Failed to build authenticator: {e}")))?;
+
+        let scope_refs: Vec<&str> = scopes.iter().map(|s| s.as_str()).collect();
+        let token = auth
+            .token(&scope_refs)
+            .await
+            .map_err(|e| GwsError::Auth(format!("OAuth flow failed: {e}")))?;
+
+        let access_token = token
+            .token()
+            .ok_or_else(|| GwsError::Auth("No access token returned".to_string()))?
+            .to_string();
+        let refresh_token = read_refresh_token_from_cache(&temp_path)?;
+
+        Ok((access_token, refresh_token))
+    }
+    .await;
+
+    let _ = std::fs::remove_file(&temp_path);
+    result
 }
 
 /// Simple URL encoding
@@ -426,57 +497,10 @@ async fn handle_login(args: &[String]) -> Result<(), GwsError> {
 
     // If proxy env vars are set, use proxy-aware OAuth flow (reqwest)
     // Otherwise use yup-oauth2 (faster, but doesn't support proxy)
-    let (access_token, refresh_token) = if has_proxy_env() {
+    let (access_token, refresh_token) = if crate::auth::has_proxy_env() {
         login_with_proxy_support(&client_id, &client_secret, &scopes).await?
     } else {
-        // No proxy - use yup-oauth2
-        let secret = yup_oauth2::ApplicationSecret {
-            client_id: client_id.clone(),
-            client_secret: client_secret.clone(),
-            auth_uri: "https://accounts.google.com/o/oauth2/auth".to_string(),
-            token_uri: "https://oauth2.googleapis.com/token".to_string(),
-            redirect_uris: vec!["http://localhost".to_string()],
-            ..Default::default()
-        };
-
-        let temp_path = config.join("credentials.tmp");
-        let _ = std::fs::remove_file(&temp_path);
-
-        let auth = yup_oauth2::InstalledFlowAuthenticator::builder(
-            secret,
-            yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
-        )
-        .with_storage(Box::new(crate::token_storage::EncryptedTokenStorage::new(
-            temp_path.clone(),
-        )))
-        .force_account_selection(true)
-        .flow_delegate(Box::new(CliFlowDelegate { login_hint: None }))
-        .build()
-        .await
-        .map_err(|e| GwsError::Auth(format!("Failed to build authenticator: {e}")))?;
-
-        let scope_refs: Vec<&str> = scopes.iter().map(|s| s.as_str()).collect();
-        let token = auth
-            .token(&scope_refs)
-            .await
-            .map_err(|e| GwsError::Auth(format!("OAuth flow failed: {e}")))?;
-
-        let access_token = token
-            .token()
-            .ok_or_else(|| GwsError::Auth("No access token returned".to_string()))?
-            .to_string();
-
-        let token_data = std::fs::read(&temp_path)
-            .ok()
-            .and_then(|bytes| crate::credential_store::decrypt(&bytes).ok())
-            .and_then(|decrypted| String::from_utf8(decrypted).ok())
-            .unwrap_or_default();
-        let refresh_token = extract_refresh_token(&token_data).ok_or_else(|| {
-            GwsError::Auth("No refresh token returned".to_string())
-        })?;
-
-        let _ = std::fs::remove_file(&temp_path);
-        (access_token, refresh_token)
+        login_with_yup_oauth(&config, &client_id, &client_secret, &scopes).await?
     };
 
     // Build credentials in the standard authorized_user format
@@ -2343,5 +2367,57 @@ mod tests {
         };
         let result = extract_scopes_from_doc(&doc, false);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn build_proxy_auth_url_encodes_scope_and_redirect_uri() {
+        let scopes = vec![
+            "https://www.googleapis.com/auth/drive".to_string(),
+            "openid".to_string(),
+        ];
+        let url = build_proxy_auth_url("client id", "http://localhost:8080/callback path", &scopes);
+
+        assert!(url.contains("client_id=client%20id"));
+        assert!(url.contains("redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fcallback%20path"));
+        assert!(url.contains(&format!(
+            "scope={}",
+            urlencoding("https://www.googleapis.com/auth/drive openid")
+        )));
+    }
+
+    #[test]
+    fn extract_authorization_code_returns_code() {
+        let code =
+            extract_authorization_code("GET /?state=abc&code=4/test-code&scope=openid HTTP/1.1")
+                .unwrap();
+        assert_eq!(code, "4/test-code");
+    }
+
+    #[test]
+    fn extract_authorization_code_rejects_missing_code() {
+        let err = extract_authorization_code("GET /?state=abc HTTP/1.1").unwrap_err();
+        assert!(err.to_string().contains("No authorization code"));
+    }
+
+    #[test]
+    fn read_refresh_token_from_cache_reads_encrypted_storage() {
+        let token_data = r#"[{"token":{"refresh_token":"1//refresh-token"}}]"#;
+        let encrypted = crate::credential_store::encrypt(token_data.as_bytes()).unwrap();
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut file, &encrypted).unwrap();
+
+        let refresh_token = read_refresh_token_from_cache(file.path()).unwrap();
+        assert_eq!(refresh_token, "1//refresh-token");
+    }
+
+    #[test]
+    fn read_refresh_token_from_cache_requires_refresh_token() {
+        let token_data = r#"[{"token":{"access_token":"ya29.no-refresh"}}]"#;
+        let encrypted = crate::credential_store::encrypt(token_data.as_bytes()).unwrap();
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut file, &encrypted).unwrap();
+
+        let err = read_refresh_token_from_cache(file.path()).unwrap_err();
+        assert!(err.to_string().contains("no refresh token was returned"));
     }
 }


### PR DESCRIPTION
## Summary

When `http_proxy`/`https_proxy`/`all_proxy` environment variables are set, use `reqwest` (which natively supports proxy) for token refresh instead of `yup-oauth2`'s `hyper`-based client (which doesn't support proxy).

This enables `gws` to work in environments that require HTTP proxy to access Google APIs (e.g., users in China).

## Changes

- **Cargo.toml**: Enable `reqwest`'s default features including proxy and SOCKS support
- **src/auth.rs**: 
  - Add `has_proxy_env()` helper to detect proxy environment variables
  - Add `refresh_token_with_reqwest()` for proxy-aware token refresh
  - When proxy env vars are detected, use `reqwest` directly instead of waiting for `yup-oauth2`'s hyper client to timeout

## Testing

Tested in an environment requiring HTTP proxy:
```bash
export https_proxy=http://127.0.0.1:7890
gws drive files list --params '{"pageSize": 5}'
# Works! Completes in ~2 seconds
```

Without this change, the command would hang waiting for hyper's connection timeout, then fail.

Fixes #422