### PR TITLE
fix: report auth errors instead of silently proceeding unauthenticated

### DIFF
--- a/.changeset/fix-auth-error-consistency.md
+++ b/.changeset/fix-auth-error-consistency.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+fix: report auth errors instead of silently proceeding unauthenticated

--- a/src/helpers/calendar.rs
+++ b/src/helpers/calendar.rs
@@ -151,7 +151,12 @@ TIPS:
                 let scopes_str: Vec<&str> = scopes.iter().map(|s| s.as_str()).collect();
                 let (token, auth_method) = match auth::get_token(&scopes_str).await {
                     Ok(t) => (Some(t), executor::AuthMethod::OAuth),
-                    Err(_) => (None, executor::AuthMethod::None),
+                    Err(_) if matches.get_flag("dry-run") => {
+                        (None, executor::AuthMethod::None)
+                    }
+                    Err(e) => {
+                        return Err(GwsError::Auth(format!("Calendar auth failed: {e}")))
+                    }
                 };
 
                 let events_res = doc.resources.get("events").ok_or_else(|| {

--- a/src/helpers/chat.rs
+++ b/src/helpers/chat.rs
@@ -80,7 +80,12 @@ TIPS:
                 let scope_strs: Vec<&str> = scopes.iter().map(|s| s.as_str()).collect();
                 let (token, auth_method) = match auth::get_token(&scope_strs).await {
                     Ok(t) => (Some(t), executor::AuthMethod::OAuth),
-                    Err(_) => (None, executor::AuthMethod::None),
+                    Err(_) if matches.get_flag("dry-run") => {
+                        (None, executor::AuthMethod::None)
+                    }
+                    Err(e) => {
+                        return Err(GwsError::Auth(format!("Chat auth failed: {e}")))
+                    }
                 };
 
                 // Method: spaces.messages.create

--- a/src/helpers/docs.rs
+++ b/src/helpers/docs.rs
@@ -72,7 +72,12 @@ TIPS:
                 let scope_strs: Vec<&str> = scopes.iter().map(|s| s.as_str()).collect();
                 let (token, auth_method) = match auth::get_token(&scope_strs).await {
                     Ok(t) => (Some(t), executor::AuthMethod::OAuth),
-                    Err(_) => (None, executor::AuthMethod::None),
+                    Err(_) if matches.get_flag("dry-run") => {
+                        (None, executor::AuthMethod::None)
+                    }
+                    Err(e) => {
+                        return Err(GwsError::Auth(format!("Docs auth failed: {e}")))
+                    }
                 };
 
                 // Method: documents.batchUpdate

--- a/src/helpers/drive.rs
+++ b/src/helpers/drive.rs
@@ -98,7 +98,12 @@ TIPS:
                 let scopes: Vec<&str> = create_method.scopes.iter().map(|s| s.as_str()).collect();
                 let (token, auth_method) = match auth::get_token(&scopes).await {
                     Ok(t) => (Some(t), executor::AuthMethod::OAuth),
-                    Err(_) => (None, executor::AuthMethod::None),
+                    Err(_) if matches.get_flag("dry-run") => {
+                        (None, executor::AuthMethod::None)
+                    }
+                    Err(e) => {
+                        return Err(GwsError::Auth(format!("Drive auth failed: {e}")))
+                    }
                 };
 
                 executor::execute_method(

--- a/src/helpers/script.rs
+++ b/src/helpers/script.rs
@@ -105,7 +105,12 @@ TIPS:
                 let scopes: Vec<&str> = update_method.scopes.iter().map(|s| s.as_str()).collect();
                 let (token, auth_method) = match auth::get_token(&scopes).await {
                     Ok(t) => (Some(t), executor::AuthMethod::OAuth),
-                    Err(_) => (None, executor::AuthMethod::None),
+                    Err(_) if matches.get_flag("dry-run") => {
+                        (None, executor::AuthMethod::None)
+                    }
+                    Err(e) => {
+                        return Err(GwsError::Auth(format!("Script auth failed: {e}")))
+                    }
                 };
 
                 let params = json!({

--- a/src/helpers/sheets.rs
+++ b/src/helpers/sheets.rs
@@ -108,7 +108,12 @@ TIPS:
                 let scope_strs: Vec<&str> = scopes.iter().map(|s| s.as_str()).collect();
                 let (token, auth_method) = match auth::get_token(&scope_strs).await {
                     Ok(t) => (Some(t), executor::AuthMethod::OAuth),
-                    Err(_) => (None, executor::AuthMethod::None),
+                    Err(_) if matches.get_flag("dry-run") => {
+                        (None, executor::AuthMethod::None)
+                    }
+                    Err(e) => {
+                        return Err(GwsError::Auth(format!("Sheets auth failed: {e}")))
+                    }
                 };
 
                 let spreadsheets_res = doc.resources.get("spreadsheets").ok_or_else(|| {
@@ -166,7 +171,12 @@ TIPS:
                 let scope_strs: Vec<&str> = scopes.iter().map(|s| s.as_str()).collect();
                 let (token, auth_method) = match auth::get_token(&scope_strs).await {
                     Ok(t) => (Some(t), executor::AuthMethod::OAuth),
-                    Err(_) => (None, executor::AuthMethod::None),
+                    Err(_) if matches.get_flag("dry-run") => {
+                        (None, executor::AuthMethod::None)
+                    }
+                    Err(e) => {
+                        return Err(GwsError::Auth(format!("Sheets auth failed: {e}")))
+                    }
                 };
 
                 executor::execute_method(


### PR DESCRIPTION
## Summary

- Six helper commands silently swallowed authentication failures and proceeded with `AuthMethod::None`, causing confusing 401 API errors downstream
- Now they return a clear `GwsError::Auth` message with the underlying error
- `--dry-run` mode still works without auth (consistent with gmail helper pattern)

## Affected helpers

| Helper | File | Command |
|--------|------|---------|
| Chat | `src/helpers/chat.rs` | `+send` |
| Drive | `src/helpers/drive.rs` | `+upload` |
| Sheets | `src/helpers/sheets.rs` | `+append`, `+read` |
| Docs | `src/helpers/docs.rs` | `+write` |
| Calendar | `src/helpers/calendar.rs` | `+insert` |
| Script | `src/helpers/script.rs` | `+push` |

## Root cause

These helpers used a silent fallback pattern:
```rust
Err(_) => (None, executor::AuthMethod::None),
```

The gmail helper already uses the correct pattern:
```rust
Err(_) if matches.get_flag("dry-run") => (None, executor::AuthMethod::None),
Err(e) => return Err(GwsError::Auth(format!("... auth failed: {e}"))),
```

## Test plan

- [x] Verified all 7 call sites across 6 files are updated
- [x] `--dry-run` exception preserved for all helpers
- [x] Existing tests continue to pass