### PR TITLE
chore: fix maintainer email typo in flake.nix and harden coverage.sh

### DIFF
--- a/.changeset/fix-nix-typo-and-scripts.md
+++ b/.changeset/fix-nix-typo-and-scripts.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+chore: fix maintainer email typo in flake.nix and harden coverage.sh

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
             description = cargoToml.package.description;
             homepage = cargoToml.package.homepage;
             license = licenses.asl20;
-            maintainers = [{ name = "Justin Poehnelt"; email = "justin.poehnelt@mgail.com"; }];
+            maintainers = [{ name = "Justin Poehnelt"; email = "justin.poehnelt@gmail.com"; }];
             mainProgram = "gws";
           };
         };

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -euo pipefail
 
 # Check if cargo-llvm-cov is installed
 if ! cargo llvm-cov --version &> /dev/null; then


### PR DESCRIPTION
## Summary

- Fix typo in `flake.nix`: `mgail.com` → `gmail.com` in maintainer email
- Add `set -euo pipefail` to `scripts/coverage.sh` (was only `set -e`), consistent with `version-sync.sh` and `tag-release.sh`

## Details

The email typo means Nix metadata points to a non-existent domain. The missing `-u` and `-o pipefail` flags mean undefined variables silently expand to empty strings and piped command failures are hidden.