### PR TITLE
fix(docs): correct broken flag names in recipes

### DIFF
--- a/.changeset/fix-recipe-flag-names.md
+++ b/.changeset/fix-recipe-flag-names.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+fix(docs): correct flag names in recipes (--spreadsheet-id, --attendees, --duration)

--- a/registry/recipes.yaml
+++ b/registry/recipes.yaml
@@ -96,8 +96,8 @@ recipes:
     services: [sheets, drive]
     steps:
       - "Create spreadsheet: `gws drive files create --json '{\"name\": \"Expense Tracker 2025\", \"mimeType\": \"application/vnd.google-apps.spreadsheet\"}'`"
-      - "Add headers: `gws sheets +append --spreadsheet-id SHEET_ID --range 'Sheet1' --values '[\"Date\", \"Category\", \"Description\", \"Amount\"]'`"
-      - "Add first entry: `gws sheets +append --spreadsheet-id SHEET_ID --range 'Sheet1' --values '[\"2025-01-15\", \"Travel\", \"Flight to NYC\", \"450.00\"]'`"
+      - "Add headers: `gws sheets +append --spreadsheet SHEET_ID --range 'Sheet1' --values '[\"Date\", \"Category\", \"Description\", \"Amount\"]'`"
+      - "Add first entry: `gws sheets +append --spreadsheet SHEET_ID --range 'Sheet1' --values '[\"2025-01-15\", \"Travel\", \"Flight to NYC\", \"450.00\"]'`"
       - "Share with manager: `gws drive permissions create --params '{\"fileId\": \"SHEET_ID\"}' --json '{\"role\": \"reader\", \"type\": \"user\", \"emailAddress\": \"manager@company.com\"}'`"
 
   - name: copy-sheet-for-new-month
@@ -170,7 +170,7 @@ recipes:
     steps:
       - "Query free/busy: `gws calendar freebusy query --json '{\"timeMin\": \"2024-03-18T08:00:00Z\", \"timeMax\": \"2024-03-18T18:00:00Z\", \"items\": [{\"id\": \"user1@company.com\"}, {\"id\": \"user2@company.com\"}]}'`"
       - "Review the output to find overlapping free slots"
-      - "Create event in the free slot: `gws calendar +insert --summary 'Meeting' --attendees user1@company.com,user2@company.com --start '2024-03-18T14:00:00' --duration 30`"
+      - "Create event in the free slot: `gws calendar +insert --summary 'Meeting' --attendee user1@company.com --attendee user2@company.com --start '2024-03-18T14:00:00' --end '2024-03-18T14:30:00'`"
 
   # ============================================================
   # DRIVE / FILE MANAGEMENT
@@ -216,8 +216,8 @@ recipes:
     services: [sheets, drive]
     steps:
       - "Find the tracking sheet: `gws drive files list --params '{\"q\": \"name = '\\''Sales Pipeline'\\'' and mimeType = '\\''application/vnd.google-apps.spreadsheet'\\''\"}'`"
-      - "Read current data: `gws sheets +read --spreadsheet-id SHEET_ID --range \"Pipeline!A1:F\"`"
-      - "Append new row: `gws sheets +append --spreadsheet-id SHEET_ID --range 'Pipeline' --values '[\"2024-03-15\", \"Acme Corp\", \"Proposal Sent\", \"$50,000\", \"Q2\", \"jdoe\"]'`"
+      - "Read current data: `gws sheets +read --spreadsheet SHEET_ID --range \"Pipeline!A1:F\"`"
+      - "Append new row: `gws sheets +append --spreadsheet SHEET_ID --range 'Pipeline' --values '[\"2024-03-15\", \"Acme Corp\", \"Proposal Sent\", \"$50,000\", \"Q2\", \"jdoe\"]'`"
 
   - name: collect-form-responses
     title: Check Form Responses
@@ -242,7 +242,7 @@ recipes:
     services: [docs, calendar, chat]
     steps:
       - "Create post-mortem doc: `gws docs +write --title 'Post-Mortem: [Incident]' --body '## Summary\\n\\n## Timeline\\n\\n## Root Cause\\n\\n## Action Items'`"
-      - "Schedule review meeting: `gws calendar +insert --summary 'Post-Mortem Review: [Incident]' --attendees team@company.com --start 'next monday 14:00' --duration 60`"
+      - "Schedule review meeting: `gws calendar +insert --summary 'Post-Mortem Review: [Incident]' --attendee team@company.com --start '2026-03-16T14:00:00' --end '2026-03-16T15:00:00'`"
       - "Notify in Chat: `gws chat +send --space spaces/ENG_SPACE --text '🔍 Post-mortem scheduled for [Incident].'`"
 
   # ============================================================
@@ -384,8 +384,8 @@ recipes:
     services: [people, sheets]
     steps:
       - "List contacts: `gws people people listDirectoryPeople --params '{\"readMask\": \"names,emailAddresses,phoneNumbers\", \"sources\": [\"DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE\"], \"pageSize\": 100}' --format json`"
-      - "Create a sheet: `gws sheets +append --spreadsheet-id SHEET_ID --range 'Contacts' --values '[\"Name\", \"Email\", \"Phone\"]'`"
-      - "Append each contact row: `gws sheets +append --spreadsheet-id SHEET_ID --range 'Contacts' --values '[\"Jane Doe\", \"jane@company.com\", \"+1-555-0100\"]'`"
+      - "Create a sheet: `gws sheets +append --spreadsheet SHEET_ID --range 'Contacts' --values '[\"Name\", \"Email\", \"Phone\"]'`"
+      - "Append each contact row: `gws sheets +append --spreadsheet SHEET_ID --range 'Contacts' --values '[\"Jane Doe\", \"jane@company.com\", \"+1-555-0100\"]'`"
 
   # ============================================================
   # CONSUMER — COLLABORATION
@@ -424,8 +424,8 @@ recipes:
     category: productivity
     services: [sheets, calendar]
     steps:
-      - "Read event data: `gws sheets +read --spreadsheet-id SHEET_ID --range \"Events!A2:D\"`"
-      - "For each row, create a calendar event: `gws calendar +insert --summary 'Team Standup' --start '2025-01-20T09:00' --duration 30 --attendees alice@company.com,bob@company.com`"
+      - "Read event data: `gws sheets +read --spreadsheet SHEET_ID --range \"Events!A2:D\"`"
+      - "For each row, create a calendar event: `gws calendar +insert --summary 'Team Standup' --start '2026-01-20T09:00:00' --end '2026-01-20T09:30:00' --attendee alice@company.com --attendee bob@company.com`"
 
   # ============================================================
   # CALENDAR — PLANNING
@@ -438,7 +438,7 @@ recipes:
     steps:
       - "Check this week's agenda: `gws calendar +agenda`"
       - "Check free/busy for the week: `gws calendar freebusy query --json '{\"timeMin\": \"2025-01-20T00:00:00Z\", \"timeMax\": \"2025-01-25T00:00:00Z\", \"items\": [{\"id\": \"primary\"}]}'`"
-      - "Add a new event: `gws calendar +insert --summary 'Deep Work Block' --start '2025-01-21T14:00' --duration 120`"
+      - "Add a new event: `gws calendar +insert --summary 'Deep Work Block' --start '2026-01-21T14:00:00' --end '2026-01-21T16:00:00'`"
       - "Review updated schedule: `gws calendar +agenda`"
   # ============================================================
   # MULTI-SERVICE PROJECT SETUP
@@ -467,7 +467,7 @@ recipes:
     steps:
       - "Get spreadsheet details: `gws sheets spreadsheets get --params '{\"spreadsheetId\": \"SHEET_ID\"}'`"
       - "Export as CSV: `gws drive files export --params '{\"fileId\": \"SHEET_ID\", \"mimeType\": \"text/csv\"}'`"
-      - "Or read values directly: `gws sheets +read --spreadsheet-id SHEET_ID --range 'Sheet1' --format csv`"
+      - "Or read values directly: `gws sheets +read --spreadsheet SHEET_ID --range 'Sheet1' --format csv`"
 
   # ============================================================
   # CALENDAR — TEAM
@@ -514,8 +514,8 @@ recipes:
     category: productivity
     services: [sheets]
     steps:
-      - "Read the first tab: `gws sheets +read --spreadsheet-id SHEET_ID --range \"January!A1:D\"`"
-      - "Read the second tab: `gws sheets +read --spreadsheet-id SHEET_ID --range \"February!A1:D\"`"
+      - "Read the first tab: `gws sheets +read --spreadsheet SHEET_ID --range \"January!A1:D\"`"
+      - "Read the second tab: `gws sheets +read --spreadsheet SHEET_ID --range \"February!A1:D\"`"
       - "Compare the data and identify changes"
 
   # ============================================================
@@ -553,7 +553,7 @@ recipes:
     category: productivity
     services: [sheets, docs, drive]
     steps:
-      - "Read the data: `gws sheets +read --spreadsheet-id SHEET_ID --range \"Sales!A1:D\"`"
+      - "Read the data: `gws sheets +read --spreadsheet SHEET_ID --range \"Sales!A1:D\"`"
       - "Create the report doc: `gws docs documents create --json '{\"title\": \"Sales Report - January 2025\"}'`"
       - "Write the report: `gws docs +write --document-id DOC_ID --text '## Sales Report - January 2025\n\n### Summary\nTotal deals: 45\nRevenue: $125,000\n\n### Top Deals\n1. Acme Corp - $25,000\n2. Widget Inc - $18,000'`"
       - "Share with stakeholders: `gws drive permissions create --params '{\"fileId\": \"DOC_ID\"}' --json '{\"role\": \"reader\", \"type\": \"user\", \"emailAddress\": \"cfo@company.com\"}'`"


### PR DESCRIPTION
## Summary

Fix 18 broken flag references across `registry/recipes.yaml` that would cause recipe commands to fail:

| Wrong flag | Correct flag | Count | Issue |
|-----------|-------------|-------|-------|
| `--spreadsheet-id` | `--spreadsheet` | 10 | Flag name mismatch |
| `--attendees a,b` | `--attendee a --attendee b` | 4 | Not a comma flag — uses `ArgAction::Append` |
| `--duration 30` | `--end <ISO8601>` | 4 | Flag does not exist |

## Impact

Any AI agent or user following these recipes verbatim would get `UnrecognizedArg` errors. Since recipes are auto-published as SKILL.md files consumed by AI agents, this directly affects agent reliability.

## Test plan

- [x] Verified all flag names match actual clap definitions in `src/helpers/sheets.rs` and `src/helpers/calendar.rs`
- [x] No remaining `--spreadsheet-id`, `--attendees`, or `--duration` references