### PR TITLE
fix(gmail): RFC 2047 encode draft address headers

### DIFF
--- a/.changeset/fix-gmail-rfc2047-draft-address-headers.md
+++ b/.changeset/fix-gmail-rfc2047-draft-address-headers.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+fix(gmail): RFC 2047 encode non-ASCII draft From/Cc/Bcc headers

--- a/src/helpers/gmail/mod.rs
+++ b/src/helpers/gmail/mod.rs
@@ -506,17 +506,26 @@ impl MessageBuilder<'_> {
         ));
 
         if let Some(from) = self.from {
-            headers.push_str(&format!("\r\nFrom: {}", sanitize_header_value(from)));
+            headers.push_str(&format!(
+                "\r\nFrom: {}",
+                encode_header_value(&sanitize_header_value(from))
+            ));
         }
 
         if let Some(cc) = self.cc {
-            headers.push_str(&format!("\r\nCc: {}", sanitize_header_value(cc)));
+            headers.push_str(&format!(
+                "\r\nCc: {}",
+                encode_header_value(&sanitize_header_value(cc))
+            ));
         }
 
         // The Gmail API reads the Bcc header to route to those recipients,
         // then strips it before delivery.
         if let Some(bcc) = self.bcc {
-            headers.push_str(&format!("\r\nBcc: {}", sanitize_header_value(bcc)));
+            headers.push_str(&format!(
+                "\r\nBcc: {}",
+                encode_header_value(&sanitize_header_value(bcc))
+            ));
         }
 
         format!("{}\r\n\r\n{}", headers, body)
@@ -1314,6 +1323,27 @@ mod tests {
 
         assert!(raw.contains("=?UTF-8?B?"));
         assert!(!raw.contains("Solar — Quote Request"));
+    }
+
+    #[test]
+    fn test_message_builder_encodes_non_ascii_optional_headers() {
+        let raw = MessageBuilder {
+            to: "alice@example.com",
+            subject: "Hello",
+            from: Some("\"日本語名前\" <from@example.com>"),
+            cc: Some("\"日本語名前\" <cc@example.com>"),
+            bcc: Some("\"日本語名前\" <bcc@example.com>"),
+            threading: None,
+            html: false,
+        }
+        .build("Body");
+
+        assert!(raw.contains("From: =?UTF-8?B?"));
+        assert!(raw.contains("Cc: =?UTF-8?B?"));
+        assert!(raw.contains("Bcc: =?UTF-8?B?"));
+        assert!(!raw.contains("From: \"日本語名前\" <from@example.com>"));
+        assert!(!raw.contains("Cc: \"日本語名前\" <cc@example.com>"));
+        assert!(!raw.contains("Bcc: \"日本語名前\" <bcc@example.com>"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes #404.

This updates Gmail draft message building to RFC 2047 encode sanitized non-ASCII `From`, `Cc`, and `Bcc` header values, matching the existing `Subject` handling.

Reproduction:
- On `origin/main`, `cargo test message_builder_encodes_non_ascii_optional_headers -- --nocapture` failed because optional draft address headers were emitted as raw UTF-8.
- With this patch, the same test passes and the full Rust validation suite passes locally.

**Dry Run Output:**
```json
Not applicable.
```

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.
