### PR TITLE
feat: add `--draft-only` mode for agent workflows

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -41,6 +41,13 @@ pub fn build_cli(doc: &RestDescription) -> Command {
                 .global(true),
         )
         .arg(
+            clap::Arg::new("draft-only")
+                .long("draft-only")
+                .help("Draft-only mode: strictly intercept and block any users.messages.send or users.drafts.send requests")
+                .action(clap::ArgAction::SetTrue)
+                .global(true),
+        )
+        .arg(
             clap::Arg::new("format")
                 .long("format")
                 .help("Output format: json (default), table, yaml, csv")

--- a/src/helpers/gmail/mod.rs
+++ b/src/helpers/gmail/mod.rs
@@ -579,6 +579,12 @@ pub(super) async fn send_raw_email(
     thread_id: Option<&str>,
     existing_token: Option<&str>,
 ) -> Result<(), GwsError> {
+    if matches.get_flag("draft-only") {
+        return Err(GwsError::Validation(
+            "Draft-only mode is enabled. Sending emails is blocked.".to_string(),
+        ));
+    }
+
     let body = build_raw_send_body(raw_message, thread_id);
     let body_str = body.to_string();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,6 +219,17 @@ async fn run() -> Result<(), GwsError> {
 
     let dry_run = matched_args.get_flag("dry-run");
 
+    let draft_only = matches.get_flag("draft-only") || matched_args.get_flag("draft-only");
+    if draft_only {
+        if let Some(ref id) = method.id {
+            if id == "gmail.users.messages.send" || id == "gmail.users.drafts.send" {
+                return Err(GwsError::Validation(
+                    "Draft-only mode is enabled. Sending emails is blocked.".to_string(),
+                ));
+            }
+        }
+    }
+
     // Build pagination config from flags
     let pagination = parse_pagination_config(matched_args);
 


### PR DESCRIPTION
Fixes #424

Adds a global `--draft-only` flag to intercept and block any `users.messages.send` or `users.drafts.send` requests in the Gmail API wrapper, returning an error. Useful for AI agent workflows to prevent accidental emails.