### PR TITLE
docs: add Homebrew as an installation option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ A Nix flake is also available at `github:googleworkspace/cli`
 nix run github:googleworkspace/cli
 ```
 
+On macOS and Linux, you can also install via [Homebrew](https://brew.sh/):
+
+```bash
+brew install googleworkspace-cli
+```
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
Closes #399.

## Summary
Add `brew install googleworkspace-cli` to the README installation section, between the Nix flake and Quick Start sections.

The formula already exists in homebrew-core: [Formula/g/googleworkspace-cli.rb](https://github.com/Homebrew/homebrew-core/blob/main/Formula/g/googleworkspace-cli.rb)

## Changes
- `README.md`: add Homebrew installation instructions

Generated with [Claude Code](https://claude.com/claude-code)