### PR TITLE
Add admin-directory as built-in service alias for Admin SDK Directory API

### DIFF
--- a/src/services.rs
+++ b/src/services.rs
@@ -55,6 +55,12 @@ pub const SERVICES: &[ServiceEntry] = &[
         description: "Audit logs and usage reports",
     },
     ServiceEntry {
+        aliases: &["admin-directory"],
+        api_name: "admin",
+        version: "directory_v1",
+        description: "Manage users, groups, and organizational units",
+    },
+    ServiceEntry {
         aliases: &["docs"],
         api_name: "docs",
         version: "v1",
@@ -163,6 +169,10 @@ mod tests {
         assert_eq!(
             resolve_service("reports").unwrap(),
             ("admin".to_string(), "reports_v1".to_string())
+        );
+        assert_eq!(
+            resolve_service("admin-directory").unwrap(),
+            ("admin".to_string(), "directory_v1".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary

This PR adds a new built-in service alias `admin-directory` for the Admin SDK Directory API (`admin:directory_v1`), addressing issue #473.

## Changes

- Add `ServiceEntry` for `admin-directory` in `src/services.rs`
- Add test case for `resolve_service("admin-directory")`

## Motivation

The Admin SDK Directory API is one of the most commonly used Google Workspace APIs for managing users, groups, and organizational units. Currently, accessing it through `gws` requires using the `admin-reports` alias with a version override:

```bash
gws admin-reports --api-version directory_v1 groups list
```

This works but is unintuitive — `admin-reports` implies audit/usage reporting, not user/group management. A built-in `admin-directory` alias makes the CLI more discoverable and self-documenting.

## Usage

After this change, users can:

```bash
gws admin-directory groups list --params '{"domain":"example.com"}'
gws admin-directory members list --params '{"groupKey":"group@example.com"}'
gws admin-directory users get --params '{"userKey":"user@example.com"}'
```

## Testing

Added unit test for `resolve_service("admin-directory")` that verifies it returns the correct (api_name, version) tuple.

Fixes: #473