### PR TITLE
fix(token_storage): propagate errors when creating/securing token dir

### DIFF
--- a/src/token_storage.rs
+++ b/src/token_storage.rs
@@ -74,11 +74,11 @@ impl EncryptedTokenStorage {
         let encrypted = crate::credential_store::encrypt(json.as_bytes())?;
 
         if let Some(parent) = self.file_path.parent() {
-            let _ = tokio::fs::create_dir_all(parent).await;
+            tokio::fs::create_dir_all(parent).await?;
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700));
+                std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))?;
             }
         }
 


### PR DESCRIPTION
Fixes #493\n\nPreviously, failures to create the token directory or set its permissions were silently ignored with `let _`. This could lead to confusing errors later when writing the token file, or worse, leave the directory with insecure permissions if the `chmod` fails. \n\nThis PR changes `let _` to `?` to ensure these errors are propagated.