### PR TITLE
fix(gmail): remove duplicate attachment arg on +send

### DIFF
--- a/.changeset/fix-send-attachment-arg.md
+++ b/.changeset/fix-send-attachment-arg.md
@@ -1,0 +1,10 @@
+---
+"@googleworkspace/cli": patch
+---
+
+fix(gmail): remove dead `--attachment` arg from `+send`
+
+The `+send` subcommand defined a duplicate `"attachment"` arg alongside the
+`"attach"` arg already provided by `common_mail_args`. Since `parse_attachments`
+reads `"attach"`, the `--attachment` flag was silently ignored. Removed the
+dead duplicate.

--- a/skills/gws-gmail-send/SKILL.md
+++ b/skills/gws-gmail-send/SKILL.md
@@ -30,7 +30,6 @@ gws gmail +send --to <EMAILS> --subject <SUBJECT> --body <TEXT>
 | `--subject` | ✓ | — | Email subject |
 | `--body` | ✓ | — | Email body (plain text, or HTML with --html) |
 | `--from` | — | — | Sender address (for send-as/alias; omit to use account default) |
-| `--attachment` | — | — | Attach a file (can be repeated for multiple files) |
 | `--attach` | — | — | Attach a file (can be specified multiple times) |
 | `--cc` | — | — | CC email address(es), comma-separated |
 | `--bcc` | — | — | BCC email address(es), comma-separated |

--- a/src/helpers/gmail/mod.rs
+++ b/src/helpers/gmail/mod.rs
@@ -922,13 +922,6 @@ impl Helper for GmailHelper {
                             .long("from")
                             .help("Sender address (for send-as/alias; omit to use account default)")
                             .value_name("EMAIL"),
-                    )
-                    .arg(
-                        Arg::new("attachment")
-                            .long("attachment")
-                            .help("Attach a file (can be repeated for multiple files)")
-                            .action(ArgAction::Append)
-                            .value_name("PATH"),
                     ),
             )
             .after_help(


### PR DESCRIPTION
## Description

The `+send` subcommand defined its own `"attachment"` arg (`--attachment`) in
addition to the `"attach"` arg (`-a`/`--attach`) already provided by
`common_mail_args`. Since `parse_attachments` reads `"attach"`, the duplicate
`"attachment"` arg was dead — `+send --attachment file.pdf` was silently
accepted by clap but the value was never read.

Removed the dead duplicate and regenerated skills. Introduced in #526.

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.