### PR TITLE
🧹 Remove unwrap() on required arguments in calendar helper

### DIFF
--- a/.changeset/remove-calendar-unwrap.md
+++ b/.changeset/remove-calendar-unwrap.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Remove unwrap() on required arguments in the calendar helper to improve error handling and prevent potential panics.

--- a/src/helpers/calendar.rs
+++ b/src/helpers/calendar.rs
@@ -424,10 +424,18 @@ fn build_insert_request(
     matches: &ArgMatches,
     doc: &crate::discovery::RestDescription,
 ) -> Result<(String, String, Vec<String>), GwsError> {
-    let calendar_id = matches.get_one::<String>("calendar").unwrap();
-    let summary = matches.get_one::<String>("summary").unwrap();
-    let start = matches.get_one::<String>("start").unwrap();
-    let end = matches.get_one::<String>("end").unwrap();
+    let calendar_id = matches
+        .get_one::<String>("calendar")
+        .ok_or_else(|| GwsError::Validation("Missing required argument: calendar".to_string()))?;
+    let summary = matches
+        .get_one::<String>("summary")
+        .ok_or_else(|| GwsError::Validation("Missing required argument: summary".to_string()))?;
+    let start = matches
+        .get_one::<String>("start")
+        .ok_or_else(|| GwsError::Validation("Missing required argument: start".to_string()))?;
+    let end = matches
+        .get_one::<String>("end")
+        .ok_or_else(|| GwsError::Validation("Missing required argument: end".to_string()))?;
     let location = matches.get_one::<String>("location");
     let description = matches.get_one::<String>("description");
     let attendees_vals = matches.get_many::<String>("attendee");


### PR DESCRIPTION
I replaced several `.unwrap()` calls in `src/helpers/calendar.rs` with proper error handling to improve code health and prevent potential panics. The affected arguments are `calendar`, `summary`, `start`, and `end`, which are now handled using `.ok_or_else(|| GwsError::Validation(...))?`. I also added a changeset file to document the improvement.

---
*PR created automatically by Jules for task [11601507632249061943](https://jules.google.com/task/11601507632249061943) started by @jpoehnelt*