### PR TITLE
feat(auth): add --port flag for orgs that block Desktop OAuth

### DIFF
--- a/src/auth_commands.rs
+++ b/src/auth_commands.rs
@@ -233,9 +233,15 @@ async fn handle_login(args: &[String]) -> Result<(), GwsError> {
             args[i].strip_prefix("--port=")
         };
         if let Some(value) = port_str {
-            fixed_port = Some(value.parse::<u16>().map_err(|_| {
+            let port = value.parse::<u16>().map_err(|_| {
                 GwsError::Validation(format!("Invalid port number: {value}"))
-            })?);
+            })?;
+            if port == 0 {
+                return Err(GwsError::Validation(
+                    "Port number must be a non-zero value between 1 and 65535.".to_string(),
+                ));
+            }
+            fixed_port = Some(port);
             continue;
         }
 


### PR DESCRIPTION
## Summary

Adds a `--port` flag to `gws auth login` that uses a fixed port for the OAuth redirect server, enabling authentication for users in organizations that block the Desktop/installed OAuth flow via `admin_policy_enforced`.

## Problem

Organizations with strict Google Workspace admin policies block the "installed" (Desktop) OAuth flow. The current implementation uses `yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect` which binds to a random port — Google identifies this as a Desktop flow pattern and some orgs block it.

## Solution

- Added `--port <PORT>` flag to `gws auth login`
- When provided: uses `HTTPPortRedirect(port)` with a fixed redirect URI (`http://localhost:<port>`) — compatible with Web Application type OAuth clients
- When omitted: preserves current behavior (random port, Desktop flow) — **no breaking change**

## Usage

```bash
# Current behavior (unchanged)
gws auth login

# For orgs that block Desktop OAuth
gws auth login --port 8080
```

Users with `admin_policy_enforced` would:
1. Create a **Web Application** (not Desktop) OAuth client in GCP Console
2. Set redirect URI to `http://localhost:8080`
3. Run `gws auth login --port 8080`

## Changes

- `src/auth_commands.rs`: Parse `--port` flag, conditionally use `HTTPPortRedirect(port)` and fixed redirect URI

## Test plan

- [x] Builds successfully (`cargo build --release`)
- [x] Without `--port`: existing behavior preserved (random port)
- [x] With `--port 8080`: fixed port used, Web Application OAuth client works
- [x] Tested with managed Google Workspace account that blocks Desktop OAuth

Closes #557