### PR TITLE
feat: restore domain-wide delegation via GOOGLE_WORKSPACE_CLI_IMPERSONATED_USER

### DIFF
--- a/.changeset/restore-dwd-impersonation.md
+++ b/.changeset/restore-dwd-impersonation.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": minor
+---
+
+Restore domain-wide delegation support for service accounts via `GOOGLE_WORKSPACE_CLI_IMPERSONATED_USER` env var

--- a/README.md
+++ b/README.md
@@ -199,6 +199,22 @@ export GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE=/path/to/service-account.json
 gws drive files list
 ```
 
+#### Domain-Wide Delegation (DWD)
+
+To access user data (Gmail, Calendar, etc.) via a service account with
+[domain-wide delegation](https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority),
+set the impersonated user:
+
+```bash
+export GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE=/path/to/service-account.json
+export GOOGLE_WORKSPACE_CLI_IMPERSONATED_USER=user@example.com
+gws gmail users messages list --params '{"userId": "me"}'
+```
+
+> **Note:** Without `GOOGLE_WORKSPACE_CLI_IMPERSONATED_USER`, service accounts
+> can only access their own resources. User-scoped APIs like Gmail and Calendar
+> require impersonation via DWD.
+
 ### Pre-obtained Access Token
 
 Useful when another tool (e.g. `gcloud`) already mints tokens for your environment.
@@ -382,6 +398,7 @@ All variables are optional. See [`.env.example`](.env.example) for a copy-paste 
 |---|---|
 | `GOOGLE_WORKSPACE_CLI_TOKEN` | Pre-obtained OAuth2 access token (highest priority) |
 | `GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE` | Path to OAuth credentials JSON (user or service account) |
+| `GOOGLE_WORKSPACE_CLI_IMPERSONATED_USER` | Email to impersonate via domain-wide delegation (service accounts only) |
 | `GOOGLE_WORKSPACE_CLI_CLIENT_ID` | OAuth client ID (alternative to `client_secret.json`) |
 | `GOOGLE_WORKSPACE_CLI_CLIENT_SECRET` | OAuth client secret (paired with `CLIENT_ID`) |
 | `GOOGLE_WORKSPACE_CLI_CONFIG_DIR` | Override config directory (default: `~/.config/gws`) |

--- a/crates/google-workspace-cli/src/auth.rs
+++ b/crates/google-workspace-cli/src/auth.rs
@@ -34,6 +34,15 @@ const PROXY_ENV_VARS: &[&str] = &[
     "ALL_PROXY",
 ];
 
+const IMPERSONATED_USER_ENV: &str = "GOOGLE_WORKSPACE_CLI_IMPERSONATED_USER";
+
+/// Returns the impersonated user email for domain-wide delegation, if set.
+pub fn get_impersonated_user() -> Option<String> {
+    std::env::var(IMPERSONATED_USER_ENV)
+        .ok()
+        .filter(|val| !val.trim().is_empty())
+}
+
 /// Response from Google's token endpoint
 #[derive(Debug, Deserialize)]
 struct TokenResponse {
@@ -220,13 +229,14 @@ pub async fn get_token(scopes: &[&str]) -> anyhow::Result<String> {
     }
 
     let creds_file = std::env::var("GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE").ok();
+    let impersonated_user = get_impersonated_user();
     let config_dir = crate::auth_commands::config_dir();
     let enc_path = credential_store::encrypted_credentials_path();
     let default_path = config_dir.join("credentials.json");
     let token_cache = config_dir.join("token_cache.json");
 
     let creds = load_credentials_inner(creds_file.as_deref(), &enc_path, &default_path).await?;
-    get_token_inner(scopes, creds, &token_cache).await
+    get_token_inner(scopes, creds, &token_cache, impersonated_user.as_deref()).await
 }
 
 /// Check if HTTP proxy environment variables are set
@@ -244,6 +254,7 @@ async fn get_token_inner(
     scopes: &[&str],
     creds: Credential,
     token_cache_path: &std::path::Path,
+    impersonated_user: Option<&str>,
 ) -> anyhow::Result<String> {
     match creds {
         Credential::AuthorizedUser(ref secret) => {
@@ -279,9 +290,14 @@ async fn get_token_inner(
                 .map(|f| f.to_string_lossy().to_string())
                 .unwrap_or_else(|| "token_cache.json".to_string());
             let sa_cache = token_cache_path.with_file_name(format!("sa_{tc_filename}"));
-            let builder = yup_oauth2::ServiceAccountAuthenticator::builder(key).with_storage(
+            let mut builder = yup_oauth2::ServiceAccountAuthenticator::builder(key).with_storage(
                 Box::new(crate::token_storage::EncryptedTokenStorage::new(sa_cache)),
             );
+
+            // Domain-wide delegation: set the impersonated user (sub claim) on the JWT
+            if let Some(user) = impersonated_user {
+                builder = builder.subject(user.to_string());
+            }
 
             let auth = builder
                 .build()

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -1233,6 +1233,11 @@ async fn handle_status() -> Result<(), GwsError> {
         "token_cache_exists": has_token_cache,
     });
 
+    // Show impersonated user if set (domain-wide delegation)
+    if let Some(user) = crate::auth::get_impersonated_user() {
+        output["impersonated_user"] = json!(user);
+    }
+
     // Show client config (client_secret.json) status
     let config_path = crate::oauth_config::client_config_path();
     let has_config = config_path.exists();

--- a/crates/google-workspace-cli/src/main.rs
+++ b/crates/google-workspace-cli/src/main.rs
@@ -487,6 +487,7 @@ fn print_usage() {
     println!(
         "    GOOGLE_WORKSPACE_CLI_KEYRING_BACKEND     Keyring backend: keyring (default) or file"
     );
+    println!("    GOOGLE_WORKSPACE_CLI_IMPERSONATED_USER   Email to impersonate via domain-wide delegation (SA only)");
     println!("    GOOGLE_WORKSPACE_CLI_SANITIZE_TEMPLATE   Default Model Armor template");
     println!(
         "    GOOGLE_WORKSPACE_CLI_SANITIZE_MODE       Sanitization mode: warn (default) or block"


### PR DESCRIPTION
## Summary

Restore service account domain-wide delegation (DWD) support via a single environment variable:

```bash
export GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE=/path/to/service-account.json
export GOOGLE_WORKSPACE_CLI_IMPERSONATED_USER=user@example.com
gws gmail +triage
```

DWD was removed as collateral damage in PR #253 alongside multi-account cleanup. However, DWD is the standard mechanism for server-to-server Google Workspace integration. Without the `sub` claim in the JWT assertion, user-scoped APIs (Gmail, Calendar) fail with `400 Precondition check failed`, even though the README documents service account usage.

This is a **minimal restoration** (~15 lines of logic):
- Reads `GOOGLE_WORKSPACE_CLI_IMPERSONATED_USER` env var
- Calls `builder.subject()` on `ServiceAccountAuthenticator` when set
- Shows `impersonated_user` in `gws auth status` output
- Documents the env var in help text and README

**Does NOT re-add**: multi-account support, `accounts.json`, `--account` flag, `gws auth list`, or `gws auth default`. Those were separate concerns correctly removed in #253.

## Context

- Related discussion: #335 (multi-account feature request), #333 (why was it removed?)
- Related issue: #528 (delegated Gmail access)
- The `yup_oauth2` crate's `ServiceAccountAuthenticator::builder().subject()` method has always supported this — this PR simply restores the one-line call

## Changes

| File | Change |
|---|---|
| `src/auth.rs` | Read env var, pass to `get_token_inner`, set `builder.subject()` |
| `src/auth_commands.rs` | Show `impersonated_user` in `auth status` JSON |
| `src/main.rs` | Add env var to help text |
| `README.md` | DWD usage section + env var table row |

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — 749 tests pass, 0 failures
- [x] Manual verification: `gws gmail +triage` successfully reads inbox via SA + DWD
- [x] Manual verification: `gws auth status` shows `impersonated_user` field
- [x] Without the env var, existing behavior is completely unchanged