### PR TITLE
fix(auth): prevent mask_secret panic on multi-byte UTF-8 secrets

### DIFF
--- a/.changeset/fix-mask-secret-utf8-panic.md
+++ b/.changeset/fix-mask-secret-utf8-panic.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Fix `mask_secret` panic on multi-byte UTF-8 secrets by using char-based indexing instead of byte-offset slicing

--- a/src/auth_commands.rs
+++ b/src/auth_commands.rs
@@ -22,17 +22,19 @@ use crate::error::GwsError;
 
 /// Mask a secret string by showing only the first 4 and last 4 characters.
 /// Strings with 8 or fewer characters are fully replaced with "***".
+///
+/// Uses char-based indexing (not byte offsets) so multi-byte UTF-8 secrets
+/// never cause a panic.
 fn mask_secret(s: &str) -> String {
     const MASK_PREFIX_LEN: usize = 4;
     const MASK_SUFFIX_LEN: usize = 4;
     const MIN_LEN_FOR_PARTIAL_MASK: usize = MASK_PREFIX_LEN + MASK_SUFFIX_LEN;
 
-    if s.len() > MIN_LEN_FOR_PARTIAL_MASK {
-        format!(
-            "{}...{}",
-            &s[..MASK_PREFIX_LEN],
-            &s[s.len() - MASK_SUFFIX_LEN..]
-        )
+    let char_count = s.chars().count();
+    if char_count > MIN_LEN_FOR_PARTIAL_MASK {
+        let prefix: String = s.chars().take(MASK_PREFIX_LEN).collect();
+        let suffix: String = s.chars().skip(char_count - MASK_SUFFIX_LEN).collect();
+        format!("{prefix}...{suffix}")
     } else {
         "***".to_string()
     }
@@ -2122,6 +2124,16 @@ mod tests {
     fn mask_secret_boundary() {
         // Exactly 9 chars — first 4 + last 4 with "..." in between
         assert_eq!(mask_secret("123456789"), "1234...6789");
+    }
+
+    #[test]
+    fn mask_secret_multibyte_utf8() {
+        // Multi-byte chars must not panic (previously used byte slicing)
+        assert_eq!(mask_secret("áéíóúñüÁÉÍÓÚ"), "áéíó...ÉÍÓÚ");
+        // Short multi-byte — should fully mask
+        assert_eq!(mask_secret("café"), "***");
+        // Exactly at boundary with multi-byte (9 Greek chars)
+        assert_eq!(mask_secret("αβγδεζηθι"), "αβγδ...ζηθι");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a runtime panic in `mask_secret()` when a credential string contains multi-byte UTF-8 characters (accented letters, emoji, CJK, etc.) near the masking boundary.

## Root Cause

The original code used **byte-level slicing** (`&s[..4]`, `&s[s.len()-4..]`) on a Rust `&str`. Rust strings are UTF-8, where a single character can be 1–4 bytes. If byte offset 4 lands inside a multi-byte character, Rust panics with `byte index is not a char boundary`.

## Fix

- `s.len()` → `s.chars().count()` (count characters, not bytes)
- `&s[..4]` → `s.chars().take(4).collect()` (first 4 characters)
- `&s[s.len()-4..]` → `s.chars().skip(n-4).collect()` (last 4 characters)

## Tests

Added `mask_secret_multibyte_utf8` test covering accented Latin, Greek alphabet, and short multi-byte strings. All **750 tests** pass with zero regressions.

## Impact

- **No breaking changes** — output is identical for ASCII inputs
- **No performance impact** — called at most twice per `export` on short strings
- **Single function, single file, single caller** (`handle_export`)

## Checklist

- [x] My code follows the `AGENTS.md` guidelines
- [x] I have run `cargo fmt --all`
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings
- [x] I have added tests that prove my fix is effective
- [x] I have provided a Changeset file