### PR TITLE
feat(skills): move skill version to metadata and track CLI version

### DIFF
--- a/.changeset/move-version-to-metadata.md
+++ b/.changeset/move-version-to-metadata.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Move version from top-level SKILL.md frontmatter to metadata and track CLI version

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Syncs the version from package.json into Cargo.toml and updates Cargo.lock.
+# Syncs the version from package.json into Cargo.toml, updates Cargo.lock, and regenerates skills.
 # Used by changesets/action as a custom version command.
 set -euo pipefail
 
@@ -26,5 +26,8 @@ if command -v nix > /dev/null 2>&1; then
   nix flake lock --update-input nixpkgs
 fi
 
+# Regenerate skills so metadata.version tracks the CLI version
+cargo run -- generate-skills --output-dir skills
+
 # Stage the changed files so changesets/action commits them
-git add Cargo.toml Cargo.lock flake.nix flake.lock
+git add Cargo.toml Cargo.lock flake.nix flake.lock skills/

--- a/skills/gws-admin-reports/SKILL.md
+++ b/skills/gws-admin-reports/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-admin-reports
-version: 1.0.0
 description: "Google Workspace Admin SDK: Audit logs and usage reports."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-calendar-agenda/SKILL.md
+++ b/skills/gws-calendar-agenda/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-calendar-agenda
-version: 1.0.0
 description: "Google Calendar: Show upcoming events across all calendars."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-calendar-insert/SKILL.md
+++ b/skills/gws-calendar-insert/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-calendar-insert
-version: 1.0.0
 description: "Google Calendar: Create a new event."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-calendar/SKILL.md
+++ b/skills/gws-calendar/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-calendar
-version: 1.0.0
 description: "Google Calendar: Manage calendars and events."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-chat-send/SKILL.md
+++ b/skills/gws-chat-send/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-chat-send
-version: 1.0.0
 description: "Google Chat: Send a message to a space."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-chat/SKILL.md
+++ b/skills/gws-chat/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-chat
-version: 1.0.0
 description: "Google Chat: Manage Chat spaces and messages."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-classroom/SKILL.md
+++ b/skills/gws-classroom/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-classroom
-version: 1.0.0
 description: "Google Classroom: Manage classes, rosters, and coursework."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-docs-write/SKILL.md
+++ b/skills/gws-docs-write/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-docs-write
-version: 1.0.0
 description: "Google Docs: Append text to a document."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-docs/SKILL.md
+++ b/skills/gws-docs/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-docs
-version: 1.0.0
 description: "Read and write Google Docs."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-drive-upload/SKILL.md
+++ b/skills/gws-drive-upload/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-drive-upload
-version: 1.0.0
 description: "Google Drive: Upload a file with automatic metadata."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-drive/SKILL.md
+++ b/skills/gws-drive/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-drive
-version: 1.0.0
 description: "Google Drive: Manage files, folders, and shared drives."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-events-renew/SKILL.md
+++ b/skills/gws-events-renew/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-events-renew
-version: 1.0.0
 description: "Google Workspace Events: Renew/reactivate Workspace Events subscriptions."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-events-subscribe/SKILL.md
+++ b/skills/gws-events-subscribe/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-events-subscribe
-version: 1.0.0
 description: "Google Workspace Events: Subscribe to Workspace events and stream them as NDJSON."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-events/SKILL.md
+++ b/skills/gws-events/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-events
-version: 1.0.0
 description: "Subscribe to Google Workspace events."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-forms/SKILL.md
+++ b/skills/gws-forms/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-forms
-version: 1.0.0
 description: "Read and write Google Forms."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-gmail-forward/SKILL.md
+++ b/skills/gws-gmail-forward/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-gmail-forward
-version: 1.0.0
 description: "Gmail: Forward a message to new recipients."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-gmail-read/SKILL.md
+++ b/skills/gws-gmail-read/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-gmail-read
-version: 1.0.0
 description: "Gmail: Read a message and extract its body or headers."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-gmail-reply-all/SKILL.md
+++ b/skills/gws-gmail-reply-all/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-gmail-reply-all
-version: 1.0.0
 description: "Gmail: Reply-all to a message (handles threading automatically)."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-gmail-reply/SKILL.md
+++ b/skills/gws-gmail-reply/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-gmail-reply
-version: 1.0.0
 description: "Gmail: Reply to a message (handles threading automatically)."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-gmail-send/SKILL.md
+++ b/skills/gws-gmail-send/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-gmail-send
-version: 1.0.0
 description: "Gmail: Send an email."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-gmail-triage/SKILL.md
+++ b/skills/gws-gmail-triage/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-gmail-triage
-version: 1.0.0
 description: "Gmail: Show unread inbox summary (sender, subject, date)."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-gmail-watch/SKILL.md
+++ b/skills/gws-gmail-watch/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-gmail-watch
-version: 1.0.0
 description: "Gmail: Watch for new emails and stream them as NDJSON."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-gmail/SKILL.md
+++ b/skills/gws-gmail/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-gmail
-version: 1.0.0
 description: "Gmail: Send, read, and manage email."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-keep/SKILL.md
+++ b/skills/gws-keep/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-keep
-version: 1.0.0
 description: "Manage Google Keep notes."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-meet/SKILL.md
+++ b/skills/gws-meet/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-meet
-version: 1.0.0
 description: "Manage Google Meet conferences."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-modelarmor-create-template/SKILL.md
+++ b/skills/gws-modelarmor-create-template/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-modelarmor-create-template
-version: 1.0.0
 description: "Google Model Armor: Create a new Model Armor template."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "security"
     requires:

--- a/skills/gws-modelarmor-sanitize-prompt/SKILL.md
+++ b/skills/gws-modelarmor-sanitize-prompt/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-modelarmor-sanitize-prompt
-version: 1.0.0
 description: "Google Model Armor: Sanitize a user prompt through a Model Armor template."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "security"
     requires:

--- a/skills/gws-modelarmor-sanitize-response/SKILL.md
+++ b/skills/gws-modelarmor-sanitize-response/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-modelarmor-sanitize-response
-version: 1.0.0
 description: "Google Model Armor: Sanitize a model response through a Model Armor template."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "security"
     requires:

--- a/skills/gws-modelarmor/SKILL.md
+++ b/skills/gws-modelarmor/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-modelarmor
-version: 1.0.0
 description: "Google Model Armor: Filter user-generated content for safety."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-people/SKILL.md
+++ b/skills/gws-people/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-people
-version: 1.0.0
 description: "Google People: Manage contacts and profiles."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-shared/SKILL.md
+++ b/skills/gws-shared/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-shared
-version: 1.0.0
 description: "gws CLI: Shared patterns for authentication, global flags, and output formatting."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-sheets-append/SKILL.md
+++ b/skills/gws-sheets-append/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-sheets-append
-version: 1.0.0
 description: "Google Sheets: Append a row to a spreadsheet."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-sheets-read/SKILL.md
+++ b/skills/gws-sheets-read/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-sheets-read
-version: 1.0.0
 description: "Google Sheets: Read values from a spreadsheet."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-sheets/SKILL.md
+++ b/skills/gws-sheets/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-sheets
-version: 1.0.0
 description: "Google Sheets: Read and write spreadsheets."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-slides/SKILL.md
+++ b/skills/gws-slides/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-slides
-version: 1.0.0
 description: "Google Slides: Read and write presentations."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-tasks/SKILL.md
+++ b/skills/gws-tasks/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-tasks
-version: 1.0.0
 description: "Google Tasks: Manage task lists and tasks."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-workflow-email-to-task/SKILL.md
+++ b/skills/gws-workflow-email-to-task/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-workflow-email-to-task
-version: 1.0.0
 description: "Google Workflow: Convert a Gmail message into a Google Tasks entry."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-workflow-file-announce/SKILL.md
+++ b/skills/gws-workflow-file-announce/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-workflow-file-announce
-version: 1.0.0
 description: "Google Workflow: Announce a Drive file in a Chat space."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-workflow-meeting-prep/SKILL.md
+++ b/skills/gws-workflow-meeting-prep/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-workflow-meeting-prep
-version: 1.0.0
 description: "Google Workflow: Prepare for your next meeting: agenda, attendees, and linked docs."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-workflow-standup-report/SKILL.md
+++ b/skills/gws-workflow-standup-report/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-workflow-standup-report
-version: 1.0.0
 description: "Google Workflow: Today's meetings + open tasks as a standup summary."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-workflow-weekly-digest/SKILL.md
+++ b/skills/gws-workflow-weekly-digest/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-workflow-weekly-digest
-version: 1.0.0
 description: "Google Workflow: Weekly summary: this week's meetings + unread email count."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/gws-workflow/SKILL.md
+++ b/skills/gws-workflow/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: gws-workflow
-version: 1.0.0
 description: "Google Workflow: Cross-service productivity workflows."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "productivity"
     requires:

--- a/skills/persona-content-creator/SKILL.md
+++ b/skills/persona-content-creator/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: persona-content-creator
-version: 1.0.0
 description: "Create, organize, and distribute content across Workspace."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "persona"
     requires:

--- a/skills/persona-customer-support/SKILL.md
+++ b/skills/persona-customer-support/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: persona-customer-support
-version: 1.0.0
 description: "Manage customer support — track tickets, respond, escalate issues."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "persona"
     requires:

--- a/skills/persona-event-coordinator/SKILL.md
+++ b/skills/persona-event-coordinator/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: persona-event-coordinator
-version: 1.0.0
 description: "Plan and manage events — scheduling, invitations, and logistics."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "persona"
     requires:

--- a/skills/persona-exec-assistant/SKILL.md
+++ b/skills/persona-exec-assistant/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: persona-exec-assistant
-version: 1.0.0
 description: "Manage an executive's schedule, inbox, and communications."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "persona"
     requires:

--- a/skills/persona-hr-coordinator/SKILL.md
+++ b/skills/persona-hr-coordinator/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: persona-hr-coordinator
-version: 1.0.0
 description: "Handle HR workflows — onboarding, announcements, and employee comms."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "persona"
     requires:

--- a/skills/persona-it-admin/SKILL.md
+++ b/skills/persona-it-admin/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: persona-it-admin
-version: 1.0.0
 description: "Administer IT — monitor security and configure Workspace."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "persona"
     requires:

--- a/skills/persona-project-manager/SKILL.md
+++ b/skills/persona-project-manager/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: persona-project-manager
-version: 1.0.0
 description: "Coordinate projects — track tasks, schedule meetings, and share docs."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "persona"
     requires:

--- a/skills/persona-researcher/SKILL.md
+++ b/skills/persona-researcher/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: persona-researcher
-version: 1.0.0
 description: "Organize research — manage references, notes, and collaboration."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "persona"
     requires:

--- a/skills/persona-sales-ops/SKILL.md
+++ b/skills/persona-sales-ops/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: persona-sales-ops
-version: 1.0.0
 description: "Manage sales workflows — track deals, schedule calls, client comms."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "persona"
     requires:

--- a/skills/persona-team-lead/SKILL.md
+++ b/skills/persona-team-lead/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: persona-team-lead
-version: 1.0.0
 description: "Lead a team — run standups, coordinate tasks, and communicate."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "persona"
     requires:

--- a/skills/recipe-backup-sheet-as-csv/SKILL.md
+++ b/skills/recipe-backup-sheet-as-csv/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-backup-sheet-as-csv
-version: 1.0.0
 description: "Export a Google Sheets spreadsheet as a CSV file for local backup or processing."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-batch-invite-to-event/SKILL.md
+++ b/skills/recipe-batch-invite-to-event/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-batch-invite-to-event
-version: 1.0.0
 description: "Add a list of attendees to an existing Google Calendar event and send notifications."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "scheduling"

--- a/skills/recipe-block-focus-time/SKILL.md
+++ b/skills/recipe-block-focus-time/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-block-focus-time
-version: 1.0.0
 description: "Create recurring focus time blocks on Google Calendar to protect deep work hours."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "scheduling"

--- a/skills/recipe-bulk-download-folder/SKILL.md
+++ b/skills/recipe-bulk-download-folder/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-bulk-download-folder
-version: 1.0.0
 description: "List and download all files from a Google Drive folder."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-collect-form-responses/SKILL.md
+++ b/skills/recipe-collect-form-responses/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-collect-form-responses
-version: 1.0.0
 description: "Retrieve and review responses from a Google Form."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-compare-sheet-tabs/SKILL.md
+++ b/skills/recipe-compare-sheet-tabs/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-compare-sheet-tabs
-version: 1.0.0
 description: "Read data from two tabs in a Google Sheet to compare and identify differences."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-copy-sheet-for-new-month/SKILL.md
+++ b/skills/recipe-copy-sheet-for-new-month/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-copy-sheet-for-new-month
-version: 1.0.0
 description: "Duplicate a Google Sheets template tab for a new month of tracking."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-create-classroom-course/SKILL.md
+++ b/skills/recipe-create-classroom-course/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-create-classroom-course
-version: 1.0.0
 description: "Create a Google Classroom course and invite students."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "education"

--- a/skills/recipe-create-doc-from-template/SKILL.md
+++ b/skills/recipe-create-doc-from-template/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-create-doc-from-template
-version: 1.0.0
 description: "Copy a Google Docs template, fill in content, and share with collaborators."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-create-events-from-sheet/SKILL.md
+++ b/skills/recipe-create-events-from-sheet/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-create-events-from-sheet
-version: 1.0.0
 description: "Read event data from a Google Sheets spreadsheet and create Google Calendar entries for each row."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-create-expense-tracker/SKILL.md
+++ b/skills/recipe-create-expense-tracker/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-create-expense-tracker
-version: 1.0.0
 description: "Set up a Google Sheets spreadsheet for tracking expenses with headers and initial entries."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-create-feedback-form/SKILL.md
+++ b/skills/recipe-create-feedback-form/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-create-feedback-form
-version: 1.0.0
 description: "Create a Google Form for feedback and share it via Gmail."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-create-gmail-filter/SKILL.md
+++ b/skills/recipe-create-gmail-filter/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-create-gmail-filter
-version: 1.0.0
 description: "Create a Gmail filter to automatically label, star, or categorize incoming messages."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-create-meet-space/SKILL.md
+++ b/skills/recipe-create-meet-space/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-create-meet-space
-version: 1.0.0
 description: "Create a Google Meet meeting space and share the join link."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "scheduling"

--- a/skills/recipe-create-presentation/SKILL.md
+++ b/skills/recipe-create-presentation/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-create-presentation
-version: 1.0.0
 description: "Create a new Google Slides presentation and add initial slides."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-create-shared-drive/SKILL.md
+++ b/skills/recipe-create-shared-drive/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-create-shared-drive
-version: 1.0.0
 description: "Create a Google Shared Drive and add members with appropriate roles."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-create-task-list/SKILL.md
+++ b/skills/recipe-create-task-list/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-create-task-list
-version: 1.0.0
 description: "Set up a new Google Tasks list with initial tasks."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-create-vacation-responder/SKILL.md
+++ b/skills/recipe-create-vacation-responder/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-create-vacation-responder
-version: 1.0.0
 description: "Enable a Gmail out-of-office auto-reply with a custom message and date range."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-draft-email-from-doc/SKILL.md
+++ b/skills/recipe-draft-email-from-doc/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-draft-email-from-doc
-version: 1.0.0
 description: "Read content from a Google Doc and use it as the body of a Gmail message."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-email-drive-link/SKILL.md
+++ b/skills/recipe-email-drive-link/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-email-drive-link
-version: 1.0.0
 description: "Share a Google Drive file and email the link with a message to recipients."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-find-free-time/SKILL.md
+++ b/skills/recipe-find-free-time/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-find-free-time
-version: 1.0.0
 description: "Query Google Calendar free/busy status for multiple users to find a meeting slot."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "scheduling"

--- a/skills/recipe-find-large-files/SKILL.md
+++ b/skills/recipe-find-large-files/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-find-large-files
-version: 1.0.0
 description: "Identify large Google Drive files consuming storage quota."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-forward-labeled-emails/SKILL.md
+++ b/skills/recipe-forward-labeled-emails/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-forward-labeled-emails
-version: 1.0.0
 description: "Find Gmail messages with a specific label and forward them to another address."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-generate-report-from-sheet/SKILL.md
+++ b/skills/recipe-generate-report-from-sheet/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-generate-report-from-sheet
-version: 1.0.0
 description: "Read data from a Google Sheet and create a formatted Google Docs report."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-label-and-archive-emails/SKILL.md
+++ b/skills/recipe-label-and-archive-emails/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-label-and-archive-emails
-version: 1.0.0
 description: "Apply Gmail labels to matching messages and archive them to keep your inbox clean."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-log-deal-update/SKILL.md
+++ b/skills/recipe-log-deal-update/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-log-deal-update
-version: 1.0.0
 description: "Append a deal status update to a Google Sheets sales tracking spreadsheet."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "sales"

--- a/skills/recipe-organize-drive-folder/SKILL.md
+++ b/skills/recipe-organize-drive-folder/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-organize-drive-folder
-version: 1.0.0
 description: "Create a Google Drive folder structure and move files into the right locations."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-plan-weekly-schedule/SKILL.md
+++ b/skills/recipe-plan-weekly-schedule/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-plan-weekly-schedule
-version: 1.0.0
 description: "Review your Google Calendar week, identify gaps, and add events to fill them."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "scheduling"

--- a/skills/recipe-post-mortem-setup/SKILL.md
+++ b/skills/recipe-post-mortem-setup/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-post-mortem-setup
-version: 1.0.0
 description: "Create a Google Docs post-mortem, schedule a Google Calendar review, and notify via Chat."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "engineering"

--- a/skills/recipe-reschedule-meeting/SKILL.md
+++ b/skills/recipe-reschedule-meeting/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-reschedule-meeting
-version: 1.0.0
 description: "Move a Google Calendar event to a new time and automatically notify all attendees."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "scheduling"

--- a/skills/recipe-review-meet-participants/SKILL.md
+++ b/skills/recipe-review-meet-participants/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-review-meet-participants
-version: 1.0.0
 description: "Review who attended a Google Meet conference and for how long."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-review-overdue-tasks/SKILL.md
+++ b/skills/recipe-review-overdue-tasks/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-review-overdue-tasks
-version: 1.0.0
 description: "Find Google Tasks that are past due and need attention."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-save-email-attachments/SKILL.md
+++ b/skills/recipe-save-email-attachments/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-save-email-attachments
-version: 1.0.0
 description: "Find Gmail messages with attachments and save them to a Google Drive folder."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-save-email-to-doc/SKILL.md
+++ b/skills/recipe-save-email-to-doc/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-save-email-to-doc
-version: 1.0.0
 description: "Save a Gmail message body into a Google Doc for archival or reference."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-schedule-recurring-event/SKILL.md
+++ b/skills/recipe-schedule-recurring-event/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-schedule-recurring-event
-version: 1.0.0
 description: "Create a recurring Google Calendar event with attendees."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "scheduling"

--- a/skills/recipe-send-team-announcement/SKILL.md
+++ b/skills/recipe-send-team-announcement/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-send-team-announcement
-version: 1.0.0
 description: "Send a team announcement via both Gmail and a Google Chat space."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "communication"

--- a/skills/recipe-share-doc-and-notify/SKILL.md
+++ b/skills/recipe-share-doc-and-notify/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-share-doc-and-notify
-version: 1.0.0
 description: "Share a Google Docs document with edit access and email collaborators the link."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-share-event-materials/SKILL.md
+++ b/skills/recipe-share-event-materials/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-share-event-materials
-version: 1.0.0
 description: "Share Google Drive files with all attendees of a Google Calendar event."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-share-folder-with-team/SKILL.md
+++ b/skills/recipe-share-folder-with-team/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-share-folder-with-team
-version: 1.0.0
 description: "Share a Google Drive folder and all its contents with a list of collaborators."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-sync-contacts-to-sheet/SKILL.md
+++ b/skills/recipe-sync-contacts-to-sheet/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-sync-contacts-to-sheet
-version: 1.0.0
 description: "Export Google Contacts directory to a Google Sheets spreadsheet."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "productivity"

--- a/skills/recipe-watch-drive-changes/SKILL.md
+++ b/skills/recipe-watch-drive-changes/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: recipe-watch-drive-changes
-version: 1.0.0
 description: "Subscribe to change notifications on a Google Drive file or folder."
 metadata:
+  version: 0.19.0
   openclaw:
     category: "recipe"
     domain: "engineering"

--- a/src/generate_skills.rs
+++ b/src/generate_skills.rs
@@ -385,9 +385,9 @@ fn render_service_skill(
     out.push_str(&format!(
         r#"---
 name: gws-{alias}
-version: 1.0.0
 description: "{trigger_desc}"
 metadata:
+  version: {version}
   openclaw:
     category: "productivity"
     requires:
@@ -397,6 +397,7 @@ metadata:
 ---
 
 "#,
+        version = env!("CARGO_PKG_VERSION"),
     ));
 
     // Title
@@ -522,9 +523,9 @@ fn render_helper_skill(
     out.push_str(&format!(
         r#"---
 name: gws-{alias}-{short}
-version: 1.0.0
 description: "{trigger_desc}"
 metadata:
+  version: {version}
   openclaw:
     category: "{category}"
     requires:
@@ -534,6 +535,7 @@ metadata:
 ---
 
 "#,
+        version = env!("CARGO_PKG_VERSION"),
     ));
 
     // Title
@@ -670,9 +672,9 @@ metadata:
 fn generate_shared_skill(base: &Path) -> Result<(), GwsError> {
     let content = r#"---
 name: gws-shared
-version: 1.0.0
 description: "gws CLI: Shared patterns for authentication, global flags, and output formatting."
 metadata:
+  version: __VERSION__
   openclaw:
     category: "productivity"
     requires:
@@ -750,9 +752,10 @@ gws <service> <resource> [sub-resource] <method> [flags]
 - For bugs or feature requests, direct users to open issues in the repository: `https://github.com/googleworkspace/cli/issues`
 - Before creating a new issue, **always** search existing issues and feature requests first
 - If a matching issue already exists, add context by commenting on the existing thread instead of creating a duplicate
-"#;
+"#
+    .replace("__VERSION__", env!("CARGO_PKG_VERSION"));
 
-    write_skill(base, "gws-shared", content)
+    write_skill(base, "gws-shared", &content)
 }
 
 fn render_persona_skill(persona: &PersonaEntry) -> String {
@@ -771,9 +774,9 @@ fn render_persona_skill(persona: &PersonaEntry) -> String {
     out.push_str(&format!(
         r#"---
 name: persona-{name}
-version: 1.0.0
 description: "{trigger_desc}"
 metadata:
+  version: {version}
   openclaw:
     category: "persona"
     requires:
@@ -804,6 +807,7 @@ metadata:
             .map(|s| format!("`gws-{s}`"))
             .collect::<Vec<_>>()
             .join(", "),
+        version = env!("CARGO_PKG_VERSION"),
         workflows = persona
             .workflows
             .iter()
@@ -843,9 +847,9 @@ fn render_recipe_skill(recipe: &RecipeEntry) -> String {
     out.push_str(&format!(
         r#"---
 name: recipe-{name}
-version: 1.0.0
 description: "{trigger_desc}"
 metadata:
+  version: {version}
   openclaw:
     category: "recipe"
     domain: "{category}"
@@ -867,6 +871,7 @@ metadata:
         description = recipe.description,
         title = recipe.title,
         category = recipe.category,
+        version = env!("CARGO_PKG_VERSION"),
         skills = required_skills,
         skills_list = recipe
             .services
@@ -1261,6 +1266,10 @@ mod tests {
         let fm = extract_frontmatter(&md);
         assert_block_style_sequences(fm);
         assert!(
+            fm.contains(&format!("version: {}", env!("CARGO_PKG_VERSION"))),
+            "frontmatter should contain version matching CLI version"
+        );
+        assert!(
             fm.contains("bins:\n"),
             "frontmatter should contain 'bins:' on its own line"
         );
@@ -1277,6 +1286,10 @@ mod tests {
         let content = std::fs::read_to_string(tmp.path().join("gws-shared/SKILL.md")).unwrap();
         let fm = extract_frontmatter(&content);
         assert_block_style_sequences(fm);
+        assert!(
+            fm.contains(&format!("version: {}", env!("CARGO_PKG_VERSION"))),
+            "shared skill frontmatter should contain version matching CLI version"
+        );
         assert!(
             fm.contains("- gws"),
             "shared skill frontmatter should contain '- gws'"
@@ -1297,6 +1310,10 @@ mod tests {
         let md = render_persona_skill(&persona);
         let fm = extract_frontmatter(&md);
         assert_block_style_sequences(fm);
+        assert!(
+            fm.contains(&format!("version: {}", env!("CARGO_PKG_VERSION"))),
+            "persona frontmatter should contain version matching CLI version"
+        );
         assert!(
             fm.contains("- gws"),
             "persona frontmatter should contain '- gws'"
@@ -1325,6 +1342,10 @@ mod tests {
         let md = render_recipe_skill(&recipe);
         let fm = extract_frontmatter(&md);
         assert_block_style_sequences(fm);
+        assert!(
+            fm.contains(&format!("version: {}", env!("CARGO_PKG_VERSION"))),
+            "recipe frontmatter should contain version matching CLI version"
+        );
         assert!(
             fm.contains("- gws"),
             "recipe frontmatter should contain '- gws'"
@@ -1369,6 +1390,10 @@ mod tests {
         );
         let fm = extract_frontmatter(&md);
         assert_block_style_sequences(fm);
+        assert!(
+            fm.contains(&format!("version: {}", env!("CARGO_PKG_VERSION"))),
+            "helper frontmatter should contain version matching CLI version"
+        );
         assert!(
             fm.contains("bins:\n"),
             "frontmatter should contain 'bins:' on its own line"


### PR DESCRIPTION
## Description

Moves the `version` field in SKILL.md frontmatter from a top-level field to `metadata.version`, and changes it from a hardcoded `1.0.0` to dynamically track the CLI version via `env!("CARGO_PKG_VERSION")`.

This is a prerequisite for adding [`skills-ref validate`](https://github.com/agentskills/agentskills/tree/main/skills-ref) to CI, which rejects `version` as a top-level frontmatter field.

Note that putting `version` under metadata is the pattern shown in the Agentskills spec: https://agentskills.io/specification

I think it makes sense to use a proper version number in the skills file, as their change should be reflected in the version.

### Changes

- **`src/generate_skills.rs`**: Updated all 5 frontmatter templates (service, helper, shared, persona, recipe) to place `version` under `metadata` as a sibling of `openclaw`, using the CLI version instead of hardcoded `1.0.0`. Added version assertions to all frontmatter tests.
- **`scripts/version-sync.sh`**: Added `cargo run -- generate-skills` so skills are regenerated with the new version during releases.
- **`skills/`**: Regenerated all 93 SKILL.md files.

**Dry Run Output:**
```json
// Not applicable — no new CLI command or API call added.
```

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.

## AI Note

I used Claude Code (Opus 4.6) to help me prepare this PR, but I reviewed it manually.