### PR TITLE
fix(ci): skip publish-skills on fork PRs

### DIFF
--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -21,6 +21,8 @@ concurrency:
 
 jobs:
   publish:
+    # Skip fork PRs — secrets (CLAWHUB_TOKEN) are not available
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Fork PRs don't have access to CLAWHUB_TOKEN, causing this workflow to always fail on external contributions. Adds fork guard to skip.