### PR TITLE
ci: add skills-ref lint step for SKILL.md validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       nix: ${{ steps.filter.outputs.nix }}
+      skills: ${{ steps.filter.outputs.skills }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
@@ -52,6 +53,8 @@ jobs:
             nix:
               - 'flake.nix'
               - 'flake.lock'
+            skills:
+              - 'skills/**'
 
   test:
     name: Test
@@ -188,6 +191,27 @@ jobs:
         run: |
           if ! git diff --exit-code skills/; then
             echo "::warning::Skills are out of date — the hourly auto-sync PR will fix this automatically."
+          fi
+
+  lint-skills:
+    name: Lint Skills
+    needs: changes
+    if: needs.changes.outputs.skills == 'true' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Validate skills
+        run: |
+          failed=0
+          for skill_dir in skills/*/; do
+            if ! uvx --from skills-ref@0.1.1 agentskills validate "$skill_dir"; then
+              failed=1
+            fi
+          done
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::One or more skills failed validation."
+            exit 1
           fi
 
   build-linux:


### PR DESCRIPTION
## Description

Adds a `lint-skills` CI job that validates all SKILL.md files using [`skills-ref validate`](https://github.com/agentskills/agentskills/tree/main/skills-ref). Runs via `uvx` (no install step needed) and triggers on `skills/**` changes or pushes to main.

**Dry Run Output:**

Not applicable — CI-only change, no new CLI command or API call.

**Example output if a skill fails validation:**

```text
Validation failed for skills/gws-calendar:
  - Unexpected fields in frontmatter: version. Only ['allowed-tools', 'compatibility', 'description', 'license', 'metadata', 'name'] are allowed.
```

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.

> **Note:** No Rust code was changed, so fmt/clippy are no-ops. No changeset is needed as this is a CI-only change that doesn't affect the published package. The CI job itself serves as the test.