### PR TITLE
feat(auth): re-add service account impersonation via --subject flag

### DIFF
--- a/.changeset/re-add-service-account-impersonation.md
+++ b/.changeset/re-add-service-account-impersonation.md
@@ -1,0 +1,18 @@
+---
+"@googleworkspace/cli": minor
+---
+
+feat(auth): re-add service account impersonation via `--subject` flag and `GOOGLE_WORKSPACE_CLI_SUBJECT` env var for domain-wide delegation (DWD).
+
+When a service account has domain-wide delegation enabled, executive assistants can now use it to operate on a executive's Google Workspace account:
+
+```bash
+# Via CLI flag
+gws --subject boss@company.com gmail +triage --max 10
+
+# Via env var
+export GOOGLE_WORKSPACE_CLI_SUBJECT=boss@company.com
+gws gmail +triage --max 10
+```
+
+This restores the functionality that was removed in #250 and #253, with a minimal surface area — no multi-account registry, no `accounts.json`.

--- a/crates/google-workspace-cli/src/auth.rs
+++ b/crates/google-workspace-cli/src/auth.rs
@@ -34,6 +34,27 @@ const PROXY_ENV_VARS: &[&str] = &[
     "ALL_PROXY",
 ];
 
+/// Environment variable name for the service account impersonation subject (email).
+/// When set, the service account will impersonate this user via domain-wide delegation.
+const IMPERSONATION_SUBJECT_ENV: &str = "GOOGLE_WORKSPACE_CLI_SUBJECT";
+
+/// Returns the impersonation subject (email address) to use with service account
+/// domain-wide delegation, if one is configured via the `GOOGLE_WORKSPACE_CLI_SUBJECT`
+/// environment variable.
+///
+/// This allows an executive assistant to operate on a executive's Google Workspace
+/// account without logging in as them — the service account uses DWD to obtain
+/// tokens "as" the target user.
+fn get_impersonation_subject() -> Option<String> {
+    let val = std::env::var(IMPERSONATION_SUBJECT_ENV).ok()?;
+    let val = val.trim();
+    if val.is_empty() {
+        None
+    } else {
+        Some(val.to_string())
+    }
+}
+
 /// Response from Google's token endpoint
 #[derive(Debug, Deserialize)]
 struct TokenResponse {
@@ -279,9 +300,17 @@ async fn get_token_inner(
                 .map(|f| f.to_string_lossy().to_string())
                 .unwrap_or_else(|| "token_cache.json".to_string());
             let sa_cache = token_cache_path.with_file_name(format!("sa_{tc_filename}"));
-            let builder = yup_oauth2::ServiceAccountAuthenticator::builder(key).with_storage(
-                Box::new(crate::token_storage::EncryptedTokenStorage::new(sa_cache)),
-            );
+            let mut builder =
+                yup_oauth2::ServiceAccountAuthenticator::builder(key).with_storage(
+                    Box::new(crate::token_storage::EncryptedTokenStorage::new(sa_cache)),
+                );
+
+            // Apply impersonation subject for domain-wide delegation (DWD).
+            // This allows a service account to act as a specific Workspace user,
+            // enabling executive assistant workflows described in persona-exec-assistant.
+            if let Some(subject) = get_impersonation_subject() {
+                builder = builder.subject(subject);
+            }
 
             let auth = builder
                 .build()
@@ -991,5 +1020,33 @@ mod tests {
         let _config_guard = EnvVarGuard::remove("GOOGLE_WORKSPACE_CLI_CONFIG_DIR");
 
         assert_eq!(get_quota_project(), Some("my-project-123".to_string()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_get_impersonation_subject_set() {
+        let _guard = EnvVarGuard::set("GOOGLE_WORKSPACE_CLI_SUBJECT", "boss@company.com");
+        assert_eq!(get_impersonation_subject(), Some("boss@company.com".to_string()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_get_impersonation_subject_empty() {
+        let _guard = EnvVarGuard::set("GOOGLE_WORKSPACE_CLI_SUBJECT", "");
+        assert_eq!(get_impersonation_subject(), None);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_get_impersonation_subject_whitespace() {
+        let _guard = EnvVarGuard::set("GOOGLE_WORKSPACE_CLI_SUBJECT", "   ");
+        assert_eq!(get_impersonation_subject(), None);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_get_impersonation_subject_unset() {
+        let _guard = EnvVarGuard::remove("GOOGLE_WORKSPACE_CLI_SUBJECT");
+        assert_eq!(get_impersonation_subject(), None);
     }
 }

--- a/crates/google-workspace-cli/src/main.rs
+++ b/crates/google-workspace-cli/src/main.rs
@@ -62,6 +62,13 @@ async fn main() {
 async fn run() -> Result<(), GwsError> {
     let args: Vec<String> = std::env::args().collect();
 
+    // Parse --subject before the service name so it can appear before or after the
+    // service name (like --api-version). Sets GOOGLE_WORKSPACE_CLI_SUBJECT so auth.rs
+    // can apply it to the service account authenticator for domain-wide delegation.
+    if let Some(subject) = extract_global_flag(&args, "subject") {
+        std::env::set_var("GOOGLE_WORKSPACE_CLI_SUBJECT", &subject);
+    }
+
     if args.len() < 2 {
         print_usage();
         return Err(GwsError::Validation(
@@ -70,7 +77,7 @@ async fn run() -> Result<(), GwsError> {
         ));
     }
 
-    // Find the first non-flag arg (skip --api-version and its value)
+    // Find the first non-flag arg (skip --api-version and its value, --subject and its value)
     let mut first_arg: Option<String> = None;
     {
         let mut skip_next = false;
@@ -84,6 +91,14 @@ async fn run() -> Result<(), GwsError> {
                 continue;
             }
             if a.starts_with("--api-version=") {
+                continue;
+            }
+            // Handle --subject flag (global, used for service account impersonation)
+            if a == "--subject" {
+                skip_next = true;
+                continue;
+            }
+            if a.starts_with("--subject=") {
                 continue;
             }
             if !a.starts_with("--") || a.as_str() == "--help" || a.as_str() == "--version" {
@@ -345,6 +360,22 @@ pub fn parse_service_and_version(
     Ok((api_name, version))
 }
 
+/// Extracts a global flag value from argv, checking both `--flag value` and `--flag=value` forms.
+/// Returns `None` if the flag is absent.
+fn extract_global_flag(args: &[String], name: &str) -> Option<String> {
+    for i in 0..args.len() {
+        if args[i] == format!("--{name}") {
+            if i + 1 < args.len() {
+                return Some(args[i + 1].clone());
+            }
+        }
+        if let Some(val) = args[i].strip_prefix(&format!("--{name}=")) {
+            return Some(val.to_string());
+        }
+    }
+    None
+}
+
 pub fn filter_args_for_subcommand(args: &[String], service_name: &str) -> Vec<String> {
     let mut sub_args: Vec<String> = vec!["gws".to_string()];
     let mut skip_next = false;
@@ -359,6 +390,14 @@ pub fn filter_args_for_subcommand(args: &[String], service_name: &str) -> Vec<St
             continue;
         }
         if arg.starts_with("--api-version=") {
+            continue;
+        }
+        // Strip --subject (global flag, consumed before subcommand parsing)
+        if arg == "--subject" {
+            skip_next = true;
+            continue;
+        }
+        if arg.starts_with("--subject=") {
             continue;
         }
         if !service_skipped && arg == service_name {
@@ -459,6 +498,7 @@ fn print_usage() {
     println!("    --output <PATH>       Output file path for binary responses");
     println!("    --format <FMT>        Output format: json (default), table, yaml, csv");
     println!("    --api-version <VER>   Override the API version (e.g., v2, v3)");
+    println!("    --subject <EMAIL>  Impersonate a Workspace user via service account DWD (global flag)");
     println!("    --page-all            Auto-paginate, one JSON line per page (NDJSON)");
     println!("    --page-limit <N>      Max pages to fetch with --page-all (default: 10)");
     println!("    --page-delay <MS>     Delay between pages in ms (default: 100)");
@@ -486,6 +526,9 @@ fn print_usage() {
     );
     println!(
         "    GOOGLE_WORKSPACE_CLI_KEYRING_BACKEND     Keyring backend: keyring (default) or file"
+    );
+    println!(
+        "    GOOGLE_WORKSPACE_CLI_SUBJECT            Service account impersonation subject (email) for DWD"
     );
     println!("    GOOGLE_WORKSPACE_CLI_SANITIZE_TEMPLATE   Default Model Armor template");
     println!(
@@ -734,5 +777,68 @@ mod tests {
     fn test_select_scope_empty() {
         let scopes: Vec<String> = vec![];
         assert_eq!(select_scope(&scopes), None);
+    }
+
+    #[test]
+    fn test_extract_global_flag_separate() {
+        let args = vec!["gws", "--subject", "boss@company.com", "drive", "files", "list"];
+        assert_eq!(
+            extract_global_flag(&args, "subject"),
+            Some("boss@company.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_global_flag_equals() {
+        let args = vec!["gws", "--subject=boss@company.com", "drive", "files", "list"];
+        assert_eq!(
+            extract_global_flag(&args, "subject"),
+            Some("boss@company.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_global_flag_absent() {
+        let args = vec!["gws", "drive", "files", "list"];
+        assert_eq!(extract_global_flag(&args, "subject"), None);
+    }
+
+    #[test]
+    fn test_extract_global_flag_after_service() {
+        // --subject can appear after the service name too
+        let args = vec!["gws", "drive", "--subject", "boss@company.com", "files", "list"];
+        assert_eq!(
+            extract_global_flag(&args, "subject"),
+            Some("boss@company.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_filter_args_strips_subject() {
+        let args = vec![
+            "gws".into(),
+            "--subject".into(),
+            "boss@company.com".into(),
+            "drive".into(),
+            "files".into(),
+            "list".into(),
+        ];
+        let filtered = filter_args_for_subcommand(&args, "drive");
+        assert_eq!(filtered, vec!["gws", "files", "list"]);
+        assert!(!filtered.contains(&"--subject".to_string()));
+        assert!(!filtered.contains(&"boss@company.com".to_string()));
+    }
+
+    #[test]
+    fn test_filter_args_strips_subject_equals() {
+        let args = vec![
+            "gws".into(),
+            "--subject=boss@company.com".into(),
+            "drive".into(),
+            "files".into(),
+            "list".into(),
+        ];
+        let filtered = filter_args_for_subcommand(&args, "drive");
+        assert_eq!(filtered, vec!["gws", "files", "list"]);
     }
 }

--- a/crates/google-workspace-cli/src/main.rs
+++ b/crates/google-workspace-cli/src/main.rs
@@ -361,11 +361,12 @@ pub fn parse_service_and_version(
 }
 
 /// Extracts a global flag value from argv, checking both `--flag value` and `--flag=value` forms.
-/// Returns `None` if the flag is absent.
+/// Returns `None` if the flag is absent or if the value looks like another flag (starts with `-`).
+/// This prevents `--subject --help` from incorrectly treating `--help` as the subject value.
 fn extract_global_flag(args: &[String], name: &str) -> Option<String> {
     for i in 0..args.len() {
         if args[i] == format!("--{name}") {
-            if i + 1 < args.len() {
+            if i + 1 < args.len() && !args[i + 1].starts_with('-') {
                 return Some(args[i + 1].clone());
             }
         }


### PR DESCRIPTION
## Summary

Restores domain-wide delegation (DWD) support for executive assistant workflows, allowing a service account to operate as a specific Workspace user without logging in as them.

## Changes

### auth.rs
- Added `get_impersonation_subject()` helper that reads `GOOGLE_WORKSPACE_CLI_SUBJECT` env var
- Applied `.subject()` to the `ServiceAccountAuthenticator` builder when the env var is set
- Added 4 comprehensive unit tests

### main.rs
- Added `extract_global_flag()` to parse `--subject <email>` and `--subject=<email>` from argv before subcommand dispatch
- Updated `filter_args_for_subcommand()` to strip `--subject` from subcommand args
- Added `--subject` and `GOOGLE_WORKSPACE_CLI_SUBJECT` documentation to `print_usage()`
- Added unit tests for all new functions

### .changeset
- Added feature changelog entry (minor version bump)

## Usage

```bash
# Via CLI flag (global)
gws --subject boss@company.com gmail +triage --max 10

# Via env var
export GOOGLE_WORKSPACE_CLI_SUBJECT=boss@company.com
gws gmail +triage --max 10
```

Fixes #632