### PR TITLE
ci: add cargo-audit workflow for dependency vulnerability scanning

### DIFF
--- a/.changeset/add-cargo-audit-ci.md
+++ b/.changeset/add-cargo-audit-ci.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Add cargo-audit CI workflow for automated dependency vulnerability scanning

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,45 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Audit
+
+on:
+  push:
+    branches: [main]
+    paths: ['Cargo.lock', 'Cargo.toml', 'crates/*/Cargo.toml']
+  pull_request:
+    branches: [main]
+    paths: ['Cargo.lock', 'Cargo.toml', 'crates/*/Cargo.toml']
+  schedule:
+    - cron: '0 6 * * *' # Daily at 06:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@a37010ded18ff788be4440302bd6830b1ae50d8b # cargo-llvm-cov
+        with:
+          tool: cargo-audit
+
+      - name: Run cargo audit
+        run: cargo audit


### PR DESCRIPTION
Adds a new `audit.yml` GitHub Actions workflow that runs `cargo audit` to detect known vulnerabilities in Cargo dependencies.

**Triggers:**
- On changes to `Cargo.lock` or `Cargo.toml` files (push/PR to main)
- Daily at 06:00 UTC (scheduled)
- Manual dispatch

**Why:** The project had no automated vulnerability scanning for its ~200 transitive Cargo dependencies. Known CVEs would go undetected until manually discovered.

Part of supply chain hardening effort.