### PR TITLE
fix: verify SHA256 checksum in npm postinstall script

### DIFF
--- a/.changeset/npm-sha256-verify.md
+++ b/.changeset/npm-sha256-verify.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Verify SHA256 checksum of downloaded binary in npm postinstall script

--- a/npm/install.js
+++ b/npm/install.js
@@ -2,6 +2,7 @@
 
 "use strict";
 
+const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
@@ -129,6 +130,23 @@ async function install() {
   try {
     console.error(`Downloading gws from ${url}`);
     await download(url, tmpFile);
+
+    // Verify SHA256 checksum
+    const sha256Url = `${url}.sha256`;
+    const sha256File = `${tmpFile}.sha256`;
+    console.error(`Verifying checksum from ${sha256Url}`);
+    await download(sha256Url, sha256File);
+
+    const expectedHash = fs.readFileSync(sha256File, "utf8").trim().split(/\s+/)[0].toLowerCase();
+    const fileBuffer = fs.readFileSync(tmpFile);
+    const actualHash = crypto.createHash("sha256").update(fileBuffer).digest("hex").toLowerCase();
+
+    if (actualHash !== expectedHash) {
+      throw new Error(
+        `SHA256 checksum mismatch!\n  Expected: ${expectedHash}\n  Actual:   ${actualHash}\nThe downloaded binary may have been tampered with.`,
+      );
+    }
+    console.error("Checksum verified ✓");
 
     console.error(`Extracting to ${INSTALL_DIR}`);
     extract(tmpFile, INSTALL_DIR);


### PR DESCRIPTION
The npm installer (`install.js`) downloads prebuilt binaries from GitHub Releases but never verified the `.sha256` checksum files that the release workflow generates alongside each archive.

**Changes:**
- Download the `.sha256` sidecar file after fetching the archive
- Compute SHA256 of the downloaded archive using Node.js `crypto`
- Compare and abort installation with a clear error on mismatch

**Why:** Without integrity verification, a compromised CDN/DNS or tampered GitHub Release could serve a malicious binary to npm users.

Part of supply chain hardening effort.