### PR TITLE
ci: pin cross-rs to v0.2.5 in release workflow

### DIFF
--- a/.changeset/pin-cross-version.md
+++ b/.changeset/pin-cross-version.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Pin cross-rs to v0.2.5 in release workflow to prevent unpinned git HEAD builds

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Install cross
         if: matrix.cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
 
       - name: Build
         run: |


### PR DESCRIPTION
The release workflow installed `cross` from unpinned git HEAD (`cargo install cross --git ...`), meaning whatever `main` pointed to at build time was used. A compromised upstream repo could inject malicious code into cross-compiled release binaries (aarch64-linux-gnu, aarch64-linux-musl, x86_64-linux-musl).

**Change:** Pin to `--tag v0.2.5` (latest release).

Part of supply chain hardening effort.