### PR TITLE
ci: use pnpm install --frozen-lockfile in release workflow

### DIFF
--- a/.changeset/frozen-lockfile-ci.md
+++ b/.changeset/frozen-lockfile-ci.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Use `pnpm install --frozen-lockfile` in CI for reproducible dependency resolution

--- a/.github/workflows/release-changesets.yml
+++ b/.github/workflows/release-changesets.yml
@@ -53,7 +53,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - run: |
           git config --global user.name "googleworkspace-bot"


### PR DESCRIPTION
The release-changesets workflow ran `pnpm install` without `--frozen-lockfile`, which could resolve different dependency versions than what was tested locally.

**Change:** Add `--frozen-lockfile` flag to ensure CI uses exactly the versions from the committed lockfile.

Part of supply chain hardening effort.