### PR TITLE
fix(auth): stop TUI from force-injecting cloud-platform scope

### DIFF
--- a/.changeset/fix-tui-cloud-platform-scope.md
+++ b/.changeset/fix-tui-cloud-platform-scope.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Stop TUI scope picker from unconditionally injecting cloud-platform scope

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -930,7 +930,7 @@ fn run_discovery_scope_picker(
     relevant_scopes: &[crate::setup::DiscoveredScope],
     services_filter: Option<&HashSet<String>>,
 ) -> Option<Vec<String>> {
-    use crate::setup::{ScopeClassification, PLATFORM_SCOPE};
+    use crate::setup::ScopeClassification;
     use crate::setup_tui::{PickerResult, SelectItem};
 
     let mut recommended_scopes = vec![];
@@ -1100,11 +1100,6 @@ fn run_discovery_scope_picker(
                         }
                     }
                 }
-            }
-
-            // Always include cloud-platform scope
-            if !selected.contains(&PLATFORM_SCOPE.to_string()) {
-                selected.push(PLATFORM_SCOPE.to_string());
             }
 
             // Hierarchical dedup: if we have both a broad scope (e.g. `.../auth/drive`)

--- a/crates/google-workspace-cli/src/setup.rs
+++ b/crates/google-workspace-cli/src/setup.rs
@@ -235,8 +235,6 @@ pub enum ScopeClassification {
     Restricted,
 }
 
-pub const PLATFORM_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
-
 /// A scope discovered from a Discovery Document.
 #[derive(Clone)]
 pub struct DiscoveredScope {


### PR DESCRIPTION
## Summary

The interactive TUI scope picker unconditionally appends `cloud-platform` after every selection (line ~1105 in `auth_commands.rs`), which contradicts `DEFAULT_SCOPES` that explicitly excludes it. This breaks users on managed Google Workspace orgs that block `cloud-platform` via admin policy.

- Removed the forced injection block
- Removed the now-unused `PLATFORM_SCOPE` constant (modelarmor defines its own `CLOUD_PLATFORM_SCOPE`)
- Users who need `cloud-platform` can still select it in the TUI or pass `--scopes cloud-platform`

Closes #562

## Test plan

- [x] `cargo test` — 783 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Verified `PLATFORM_SCOPE` had no other usages before removing