### PR TITLE
fix(gmail): make header parsing case-insensitive per RFC 5322

### DIFF
--- a/src/helpers/gmail/mod.rs
+++ b/src/helpers/gmail/mod.rs
@@ -111,15 +111,15 @@ fn parse_message_headers(headers: &[Value]) -> ParsedMessageHeaders {
         let name = header.get("name").and_then(|v| v.as_str()).unwrap_or("");
         let value = header.get("value").and_then(|v| v.as_str()).unwrap_or("");
 
-        match name {
-            "From" => parsed.from = value.to_string(),
-            "Reply-To" => append_address_list_header_value(&mut parsed.reply_to, value),
-            "To" => append_address_list_header_value(&mut parsed.to, value),
-            "Cc" => append_address_list_header_value(&mut parsed.cc, value),
-            "Subject" => parsed.subject = value.to_string(),
-            "Date" => parsed.date = value.to_string(),
-            "Message-ID" | "Message-Id" => parsed.message_id_header = value.to_string(),
-            "References" => append_header_value(&mut parsed.references, value),
+        match name.to_ascii_lowercase().as_str() {
+            "from" => parsed.from = value.to_string(),
+            "reply-to" => append_address_list_header_value(&mut parsed.reply_to, value),
+            "to" => append_address_list_header_value(&mut parsed.to, value),
+            "cc" => append_address_list_header_value(&mut parsed.cc, value),
+            "subject" => parsed.subject = value.to_string(),
+            "date" => parsed.date = value.to_string(),
+            "message-id" => parsed.message_id_header = value.to_string(),
+            "references" => append_header_value(&mut parsed.references, value),
             _ => {}
         }
     }


### PR DESCRIPTION
## Summary

Fixes issue #642 - parse_message_headers used case-sensitive string matching, causing CC headers with non-canonical casing (e.g., 'CC' from Microsoft Exchange) to be silently dropped.

## Root Cause

The original code used exact case matching, dropping headers like 'CC' when only 'Cc' was matched.

Per RFC 5322 §1.2.2, header field names are case-insensitive. The Gmail API preserves original header casing from the sending MTA.

## Fix

Normalize header name to lowercase before matching:

```rust
match name.to_ascii_lowercase().as_str() {
    "from" => ...
    "cc" => ...  // now matches "Cc", "CC", "cc"
}
```

This aligns with the existing `get_part_header` pattern which already uses `eq_ignore_ascii_case`.