### PR TITLE
fix(auth): skip scope picker when `gws auth login --services` is provided

### DIFF
--- a/.changeset/fix-auth-login-services.md
+++ b/.changeset/fix-auth-login-services.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Skip the auth scope picker when `gws auth login --services` is provided and accept exact scope short names in the filter.

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -776,7 +776,10 @@ async fn resolve_scopes(
     }
 
     // Interactive scope picker when running in a TTY
-    if !cfg!(test) && std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+    if should_run_interactive_scope_picker(scope_mode, services_filter)
+        && !cfg!(test)
+        && std::io::IsTerminal::is_terminal(&std::io::stdin())
+    {
         // If we have a project_id, use discovery-based scope picker (rich templates)
         if let Some(pid) = project_id {
             let enabled_apis = crate::setup::get_enabled_apis(pid);
@@ -803,6 +806,14 @@ async fn resolve_scopes(
     result
 }
 
+fn should_run_interactive_scope_picker(
+    scope_mode: ScopeMode,
+    services_filter: Option<&HashSet<String>>,
+) -> bool {
+    matches!(scope_mode, ScopeMode::Default)
+        && !services_filter.is_some_and(|services| !services.is_empty())
+}
+
 /// Check if a scope URL belongs to one of the specified services.
 ///
 /// Matching is done on the scope's short name (the part after
@@ -816,6 +827,10 @@ fn scope_matches_service(scope_url: &str, services: &HashSet<String>) -> bool {
     let short = scope_url
         .strip_prefix("https://www.googleapis.com/auth/")
         .unwrap_or(scope_url);
+
+    if services.contains(short) {
+        return true;
+    }
 
     // cloud-platform is a cross-service scope, always include
     if short == "cloud-platform" {
@@ -2348,6 +2363,32 @@ mod tests {
         ];
         let result = filter_redundant_restrictive_scopes(scopes);
         assert_eq!(result, vec!["https://mail.google.com/"]);
+    }
+
+    #[test]
+    fn scope_matches_service_accepts_exact_scope_short_name() {
+        let services = HashSet::from([String::from("documents.readonly")]);
+        assert!(scope_matches_service(
+            "https://www.googleapis.com/auth/documents.readonly",
+            &services
+        ));
+    }
+
+    #[test]
+    fn interactive_picker_skipped_when_services_filter_is_provided() {
+        let services = HashSet::from([String::from("gmail")]);
+        assert!(!should_run_interactive_scope_picker(
+            ScopeMode::Default,
+            Some(&services)
+        ));
+    }
+
+    #[test]
+    fn interactive_picker_allowed_for_plain_default_login() {
+        assert!(should_run_interactive_scope_picker(
+            ScopeMode::Default,
+            None
+        ));
     }
 
     #[test]

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -776,7 +776,7 @@ async fn resolve_scopes(
     }
 
     // Interactive scope picker when running in a TTY
-    if should_run_interactive_scope_picker(scope_mode, services_filter)
+    if should_run_interactive_scope_picker(&scope_mode, services_filter)
         && !cfg!(test)
         && std::io::IsTerminal::is_terminal(&std::io::stdin())
     {
@@ -807,11 +807,13 @@ async fn resolve_scopes(
 }
 
 fn should_run_interactive_scope_picker(
-    scope_mode: ScopeMode,
+    scope_mode: &ScopeMode,
     services_filter: Option<&HashSet<String>>,
 ) -> bool {
     matches!(scope_mode, ScopeMode::Default)
-        && services_filter.is_none_or(|services| services.is_empty())
+        && services_filter
+            .as_ref()
+            .map_or(true, |services| services.is_empty())
 }
 
 /// Check if a scope URL belongs to one of the specified services.

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -811,7 +811,7 @@ fn should_run_interactive_scope_picker(
     services_filter: Option<&HashSet<String>>,
 ) -> bool {
     matches!(scope_mode, ScopeMode::Default)
-        && !services_filter.is_some_and(|services| !services.is_empty())
+        && services_filter.is_none_or(|services| services.is_empty())
 }
 
 /// Check if a scope URL belongs to one of the specified services.


### PR DESCRIPTION
Supersedes #645, which was auto-closed by the stale bot.

## Description

Fixes #577.

This change makes `gws auth login --services ...` skip the interactive scope picker in default login mode and resolve scopes directly from the provided service filter.

It also improves service filtering so exact scope short names such as `documents.readonly` are accepted in addition to prefix-based matches.

**Dry Run Output:** Not applicable for this bug fix.

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.
