### PR TITLE
fix(gmail): use case-insensitive matching for email headers in parse_message_headers

### DIFF
--- a/.changeset/fix-header-case-insensitive.md
+++ b/.changeset/fix-header-case-insensitive.md
@@ -1,0 +1,7 @@
+---
+"@googleworkspace/cli": patch
+---
+
+fix(gmail): use case-insensitive matching for email headers in parse_message_headers
+
+The Gmail API preserves original header casing from the sending MTA (e.g., Microsoft Exchange emits "CC" instead of "Cc"). Per RFC 5322, header field names are case-insensitive. This change normalizes header names to lowercase before matching, consistent with the existing `get_part_header` function in the same file.

--- a/crates/google-workspace-cli/src/helpers/gmail/mod.rs
+++ b/crates/google-workspace-cli/src/helpers/gmail/mod.rs
@@ -258,15 +258,15 @@ fn parse_message_headers(headers: &[Value]) -> ParsedMessageHeaders {
         let name = header.get("name").and_then(|v| v.as_str()).unwrap_or("");
         let value = header.get("value").and_then(|v| v.as_str()).unwrap_or("");
 
-        match name {
-            "From" => parsed.from = value.to_string(),
-            "Reply-To" => append_address_list_header_value(&mut parsed.reply_to, value),
-            "To" => append_address_list_header_value(&mut parsed.to, value),
-            "Cc" => append_address_list_header_value(&mut parsed.cc, value),
-            "Subject" => parsed.subject = value.to_string(),
-            "Date" => parsed.date = value.to_string(),
-            "Message-ID" | "Message-Id" => parsed.message_id = value.to_string(),
-            "References" => append_header_value(&mut parsed.references, value),
+        match name.to_ascii_lowercase().as_str() {
+            "from" => parsed.from = value.to_string(),
+            "reply-to" => append_address_list_header_value(&mut parsed.reply_to, value),
+            "to" => append_address_list_header_value(&mut parsed.to, value),
+            "cc" => append_address_list_header_value(&mut parsed.cc, value),
+            "subject" => parsed.subject = value.to_string(),
+            "date" => parsed.date = value.to_string(),
+            "message-id" => parsed.message_id = value.to_string(),
+            "references" => append_header_value(&mut parsed.references, value),
             _ => {}
         }
     }
@@ -2138,6 +2138,61 @@ mod tests {
         assert!(original.date.is_none());
         assert!(original.references.is_empty());
         assert!(original.body_html.is_none());
+    }
+
+    #[test]
+    fn test_parse_message_headers_all_uppercase() {
+        let headers = vec![
+            json!({ "name": "FROM", "value": "alice@example.com" }),
+            json!({ "name": "TO", "value": "bob@example.com" }),
+            json!({ "name": "CC", "value": "carol@example.com, dave@example.com" }),
+            json!({ "name": "SUBJECT", "value": "Uppercase" }),
+            json!({ "name": "DATE", "value": "Mon, 1 Jan 2026 00:00:00 +0000" }),
+            json!({ "name": "MESSAGE-ID", "value": "<upper@example.com>" }),
+            json!({ "name": "REFERENCES", "value": "<ref1@example.com>" }),
+            json!({ "name": "REPLY-TO", "value": "reply@example.com" }),
+        ];
+        let parsed = parse_message_headers(&headers);
+        assert_eq!(parsed.from, "alice@example.com");
+        assert_eq!(parsed.to, "bob@example.com");
+        assert_eq!(parsed.cc, "carol@example.com, dave@example.com");
+        assert_eq!(parsed.subject, "Uppercase");
+        assert_eq!(parsed.date, "Mon, 1 Jan 2026 00:00:00 +0000");
+        assert_eq!(parsed.message_id, "<upper@example.com>");
+        assert_eq!(parsed.references, "<ref1@example.com>");
+        assert_eq!(parsed.reply_to, "reply@example.com");
+    }
+
+    #[test]
+    fn test_parse_message_headers_all_lowercase() {
+        let headers = vec![
+            json!({ "name": "from", "value": "alice@example.com" }),
+            json!({ "name": "to", "value": "bob@example.com" }),
+            json!({ "name": "cc", "value": "carol@example.com" }),
+            json!({ "name": "subject", "value": "Lowercase" }),
+            json!({ "name": "message-id", "value": "<lower@example.com>" }),
+        ];
+        let parsed = parse_message_headers(&headers);
+        assert_eq!(parsed.from, "alice@example.com");
+        assert_eq!(parsed.to, "bob@example.com");
+        assert_eq!(parsed.cc, "carol@example.com");
+        assert_eq!(parsed.subject, "Lowercase");
+        assert_eq!(parsed.message_id, "<lower@example.com>");
+    }
+
+    #[test]
+    fn test_parse_message_headers_mixed_case() {
+        let headers = vec![
+            json!({ "name": "From", "value": "alice@example.com" }),
+            json!({ "name": "CC", "value": "carol@example.com" }),
+            json!({ "name": "message-id", "value": "<mixed@example.com>" }),
+            json!({ "name": "REPLY-TO", "value": "reply@example.com" }),
+        ];
+        let parsed = parse_message_headers(&headers);
+        assert_eq!(parsed.from, "alice@example.com");
+        assert_eq!(parsed.cc, "carol@example.com");
+        assert_eq!(parsed.message_id, "<mixed@example.com>");
+        assert_eq!(parsed.reply_to, "reply@example.com");
     }
 
     #[test]

--- a/crates/google-workspace-cli/src/helpers/gmail/mod.rs
+++ b/crates/google-workspace-cli/src/helpers/gmail/mod.rs
@@ -258,15 +258,23 @@ fn parse_message_headers(headers: &[Value]) -> ParsedMessageHeaders {
         let name = header.get("name").and_then(|v| v.as_str()).unwrap_or("");
         let value = header.get("value").and_then(|v| v.as_str()).unwrap_or("");
 
-        match name.to_ascii_lowercase().as_str() {
-            "from" => parsed.from = value.to_string(),
-            "reply-to" => append_address_list_header_value(&mut parsed.reply_to, value),
-            "to" => append_address_list_header_value(&mut parsed.to, value),
-            "cc" => append_address_list_header_value(&mut parsed.cc, value),
-            "subject" => parsed.subject = value.to_string(),
-            "date" => parsed.date = value.to_string(),
-            "message-id" => parsed.message_id = value.to_string(),
-            "references" => append_header_value(&mut parsed.references, value),
+        match name {
+            s if s.eq_ignore_ascii_case("from") => parsed.from = value.to_string(),
+            s if s.eq_ignore_ascii_case("reply-to") => {
+                append_address_list_header_value(&mut parsed.reply_to, value)
+            }
+            s if s.eq_ignore_ascii_case("to") => {
+                append_address_list_header_value(&mut parsed.to, value)
+            }
+            s if s.eq_ignore_ascii_case("cc") => {
+                append_address_list_header_value(&mut parsed.cc, value)
+            }
+            s if s.eq_ignore_ascii_case("subject") => parsed.subject = value.to_string(),
+            s if s.eq_ignore_ascii_case("date") => parsed.date = value.to_string(),
+            s if s.eq_ignore_ascii_case("message-id") => parsed.message_id = value.to_string(),
+            s if s.eq_ignore_ascii_case("references") => {
+                append_header_value(&mut parsed.references, value)
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
## Description

`parse_message_headers` uses exact case-sensitive string matching for header names (`"Cc"`, `"From"`, etc.), but the Gmail API preserves original header casing from the sending MTA. Per RFC 5322 §1.2.2, header field names are case-insensitive.

This causes `+reply-all` (and other commands) to silently drop CC recipients when the original message was sent through an MTA that uses non-canonical casing (e.g., Microsoft Exchange emits `"CC"` instead of `"Cc"`).

### Root cause

```rust
// Before: exact match — "CC" falls through to _ => {}
match name {
    "Cc" => append_address_list_header_value(&mut parsed.cc, value),
    ...
}
```

### Fix

Use `eq_ignore_ascii_case` match guards for zero-allocation case-insensitive matching, consistent with the existing `get_part_header` and `extract_header` functions in the same file.

```rust
// After: case-insensitive — "CC", "Cc", "cc" all match
match name {
    s if s.eq_ignore_ascii_case("cc") => {
        append_address_list_header_value(&mut parsed.cc, value)
    }
    ...
}
```

This also simplifies the `Message-ID` arm from `"Message-ID" | "Message-Id"` to just `eq_ignore_ascii_case("message-id")`.

### Scope

All headers in the match block are affected, not just `Cc`:

| Header | Impact if missed |
|--------|-----------------|
| `From` | Hard error (`"Message is missing From header"`) |
| `Message-ID` | Hard error (`"Message is missing Message-ID header"`) |
| `To` | `+reply-all` misses To recipients |
| `CC` | `+reply-all` drops CC recipients |
| `Reply-To` | Reply goes to wrong recipient |
| `References` | Threading breaks |

### Tests

3 new tests (701 total, up from 698):
- `test_parse_message_headers_all_uppercase` — all-caps headers (Exchange/Outlook pattern)
- `test_parse_message_headers_all_lowercase` — all-lowercase headers
- `test_parse_message_headers_mixed_case` — canonical + non-canonical mix

All existing tests pass unchanged.

Fixes #642

> **Note:** This is a resubmission of #643, which was auto-closed due to 72h inactivity.

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.