### PR TITLE
fix(ci): add grace period to stale PR bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,7 +30,7 @@ jobs:
           days-before-issue-stale: -1
           days-before-issue-close: -1
           days-before-pr-stale: 3
-          days-before-pr-close: 0
-          stale-pr-message: 'This PR has been inactive for 72 hours. Closing to keep the queue clean.'
-          close-pr-message: 'This PR was closed because it has been stalled for 72 hours. Feel free to magically reopen it if you want to continue working on it!'
+          days-before-pr-close: 4
+          stale-pr-message: 'This PR has been inactive for 3 days. It will be closed in 4 days if there is no further activity. Comment or push to reset the timer.'
+          close-pr-message: 'This PR was closed after 7 days of inactivity. Feel free to reopen it if you want to continue working on it.'
           exempt-pr-labels: 'keep-alive'


### PR DESCRIPTION
## Description

The stale bot currently marks PRs stale after 3 days and closes them instantly in the same run (`days-before-pr-close: 0`). Contributors see the stale warning and close message simultaneously, with no chance to respond.

This has caused multiple community PRs to be auto-closed and re-filed as duplicates: #554→#589, #634→#665, #643→#667→#674.

This PR adds a 4-day grace period after the 3-day stale mark (7 days total before close). The stale warning now tells contributors they can comment or push to reset the timer.

### Before

- Day 3: PR marked stale **and** closed in the same run

### After

- Day 3: PR marked stale with a warning comment
- Days 3–7: contributor can comment or push to reset the timer
- Day 7: PR closed if still inactive