### PR TITLE
docs(skills): clarify selective installs

### DIFF
--- a/.changeset/fix-selective-skill-install.md
+++ b/.changeset/fix-selective-skill-install.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Clarify selective skill installation by requiring `gws-shared` alongside service skills and by keeping `gws generate-skills` as the local generation path.

--- a/README.md
+++ b/README.md
@@ -224,9 +224,12 @@ The repo ships 100+ Agent Skills (`SKILL.md` files) — one for every supported 
 npx skills add https://github.com/googleworkspace/cli
 
 # Or pick only what you need
+npx skills add https://github.com/googleworkspace/cli/tree/main/skills/gws-shared
 npx skills add https://github.com/googleworkspace/cli/tree/main/skills/gws-drive
 npx skills add https://github.com/googleworkspace/cli/tree/main/skills/gws-gmail
 ```
+
+When you selectively install skills, always install `gws-shared` first so the service skills can rely on the shared auth, flag, and safety guidance.
 
 <details>
 <summary>OpenClaw setup</summary>
@@ -236,7 +239,7 @@ npx skills add https://github.com/googleworkspace/cli/tree/main/skills/gws-gmail
 ln -s $(pwd)/skills/gws-* ~/.openclaw/skills/
 
 # Or copy specific skills
-cp -r skills/gws-drive skills/gws-gmail ~/.openclaw/skills/
+cp -r skills/gws-shared skills/gws-drive skills/gws-gmail ~/.openclaw/skills/
 ```
 
 The `gws-shared` skill includes an `install` block so OpenClaw auto-installs the CLI via `npm` if `gws` isn't on PATH.

--- a/crates/google-workspace-cli/src/generate_skills.rs
+++ b/crates/google-workspace-cli/src/generate_skills.rs
@@ -404,7 +404,7 @@ metadata:
     out.push_str(&format!("# {alias} ({api_version})\n\n"));
 
     out.push_str(
-        "> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.\n\n",
+        "> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.\n\n",
     );
 
     out.push_str(&format!(
@@ -541,7 +541,7 @@ metadata:
     out.push_str(&format!("# {alias} {cmd_name}\n\n"));
 
     out.push_str(
-        "> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.\n\n",
+        "> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.\n\n",
     );
 
     out.push_str(&format!("{about}\n\n"));
@@ -1399,5 +1399,71 @@ mod tests {
             fm.contains("- gws"),
             "frontmatter should contain '- gws' block entry"
         );
+    }
+
+    #[test]
+    fn test_service_skill_prerequisite_mentions_selective_install_and_local_generation() {
+        let entry = services::SERVICES
+            .iter()
+            .find(|s| s.api_name == "drive")
+            .unwrap();
+        let doc = crate::discovery::RestDescription {
+            name: entry.api_name.to_string(),
+            title: Some("Google Drive API".to_string()),
+            description: Some(entry.description.to_string()),
+            ..Default::default()
+        };
+        let cli = crate::commands::build_cli(&doc);
+        let helpers: Vec<&Command> = cli
+            .get_subcommands()
+            .filter(|s| s.get_name().starts_with('+'))
+            .collect();
+        let resources: Vec<&Command> = cli
+            .get_subcommands()
+            .filter(|s| !s.get_name().starts_with('+'))
+            .collect();
+
+        let md = render_service_skill(
+            entry.aliases[0],
+            entry,
+            &helpers,
+            &resources,
+            "Google Drive",
+            &doc,
+        );
+
+        assert!(md.contains("install `gws-shared` alongside this skill"));
+        assert!(md.contains("If you're generating skills from a local checkout, run `gws generate-skills`"));
+    }
+
+    #[test]
+    fn test_helper_skill_prerequisite_mentions_selective_install_and_local_generation() {
+        let entry = services::SERVICES
+            .iter()
+            .find(|s| s.api_name == "drive")
+            .unwrap();
+
+        let doc = crate::discovery::RestDescription {
+            name: entry.api_name.to_string(),
+            title: Some("Google Drive API".to_string()),
+            description: Some(entry.description.to_string()),
+            ..Default::default()
+        };
+        let cli = crate::commands::build_cli(&doc);
+        let helper = cli
+            .get_subcommands()
+            .find(|s| s.get_name().starts_with('+'))
+            .expect("No helper command found for test");
+
+        let md = render_helper_skill(
+            entry.aliases[0],
+            helper.get_name(),
+            helper,
+            entry,
+            "Google Drive",
+        );
+
+        assert!(md.contains("install `gws-shared` alongside this skill"));
+        assert!(md.contains("If you're generating skills from a local checkout, run `gws generate-skills`"));
     }
 }

--- a/skills/gws-admin-reports/SKILL.md
+++ b/skills/gws-admin-reports/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # admin-reports (reports_v1)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws admin-reports <resource> <method> [flags]

--- a/skills/gws-calendar-agenda/SKILL.md
+++ b/skills/gws-calendar-agenda/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # calendar +agenda
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Show upcoming events across all calendars
 

--- a/skills/gws-calendar-insert/SKILL.md
+++ b/skills/gws-calendar-insert/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # calendar +insert
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 create a new event
 

--- a/skills/gws-calendar/SKILL.md
+++ b/skills/gws-calendar/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # calendar (v3)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws calendar <resource> <method> [flags]

--- a/skills/gws-chat-send/SKILL.md
+++ b/skills/gws-chat-send/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # chat +send
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Send a message to a space
 

--- a/skills/gws-chat/SKILL.md
+++ b/skills/gws-chat/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # chat (v1)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws chat <resource> <method> [flags]

--- a/skills/gws-classroom/SKILL.md
+++ b/skills/gws-classroom/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # classroom (v1)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws classroom <resource> <method> [flags]

--- a/skills/gws-docs-write/SKILL.md
+++ b/skills/gws-docs-write/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # docs +write
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Append text to a document
 

--- a/skills/gws-docs/SKILL.md
+++ b/skills/gws-docs/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # docs (v1)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws docs <resource> <method> [flags]

--- a/skills/gws-drive-upload/SKILL.md
+++ b/skills/gws-drive-upload/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # drive +upload
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Upload a file with automatic metadata
 

--- a/skills/gws-drive/SKILL.md
+++ b/skills/gws-drive/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # drive (v3)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws drive <resource> <method> [flags]

--- a/skills/gws-events-renew/SKILL.md
+++ b/skills/gws-events-renew/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # events +renew
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Renew/reactivate Workspace Events subscriptions
 

--- a/skills/gws-events-subscribe/SKILL.md
+++ b/skills/gws-events-subscribe/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # events +subscribe
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Subscribe to Workspace events and stream them as NDJSON
 

--- a/skills/gws-events/SKILL.md
+++ b/skills/gws-events/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # events (v1)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws events <resource> <method> [flags]
@@ -38,11 +38,11 @@ gws events <resource> <method> [flags]
 
 ### subscriptions
 
-  - `create` — Creates a Google Workspace subscription. To learn how to use this method, see [Create a Google Workspace subscription](https://developers.google.com/workspace/events/guides/create-subscription).
+  - `create` — Creates a Google Workspace subscription. To learn how to use this method, see [Create a Google Workspace subscription](https://developers.google.com/workspace/events/guides/create-subscription). For a subscription on a [Chat target resource](https://developers.google.com/workspace/events/guides/events-chat), you can create a subscription as: - A Chat app by specifying an authorization scope that begins with `chat.app` and getting one-time administrator approval.
   - `delete` — Deletes a Google Workspace subscription. To learn how to use this method, see [Delete a Google Workspace subscription](https://developers.google.com/workspace/events/guides/delete-subscription).
   - `get` — Gets details about a Google Workspace subscription. To learn how to use this method, see [Get details about a Google Workspace subscription](https://developers.google.com/workspace/events/guides/get-subscription).
   - `list` — Lists Google Workspace subscriptions. To learn how to use this method, see [List Google Workspace subscriptions](https://developers.google.com/workspace/events/guides/list-subscriptions).
-  - `patch` — Updates or renews a Google Workspace subscription. To learn how to use this method, see [Update or renew a Google Workspace subscription](https://developers.google.com/workspace/events/guides/update-subscription).
+  - `patch` — Updates or renews a Google Workspace subscription. To learn how to use this method, see [Update or renew a Google Workspace subscription](https://developers.google.com/workspace/events/guides/update-subscription). For a subscription on a [Chat target resource](https://developers.google.com/workspace/events/guides/events-chat), you can update a subscription as: - A Chat app by specifying an authorization scope that begins with `chat.app` and getting one-time administrator approval.
   - `reactivate` — Reactivates a suspended Google Workspace subscription. This method resets your subscription's `State` field to `ACTIVE`. Before you use this method, you must fix the error that suspended the subscription. This method will ignore or reject any subscription that isn't currently in a suspended state. To learn how to use this method, see [Reactivate a Google Workspace subscription](https://developers.google.com/workspace/events/guides/reactivate-subscription).
 
 ### tasks

--- a/skills/gws-forms/SKILL.md
+++ b/skills/gws-forms/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # forms (v1)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws forms <resource> <method> [flags]

--- a/skills/gws-gmail-forward/SKILL.md
+++ b/skills/gws-gmail-forward/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # gmail +forward
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Forward a message to new recipients
 

--- a/skills/gws-gmail-read/SKILL.md
+++ b/skills/gws-gmail-read/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # gmail +read
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Read a message and extract its body or headers
 

--- a/skills/gws-gmail-reply-all/SKILL.md
+++ b/skills/gws-gmail-reply-all/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # gmail +reply-all
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Reply-all to a message (handles threading automatically)
 

--- a/skills/gws-gmail-reply/SKILL.md
+++ b/skills/gws-gmail-reply/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # gmail +reply
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Reply to a message (handles threading automatically)
 

--- a/skills/gws-gmail-send/SKILL.md
+++ b/skills/gws-gmail-send/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # gmail +send
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Send an email
 

--- a/skills/gws-gmail-triage/SKILL.md
+++ b/skills/gws-gmail-triage/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # gmail +triage
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Show unread inbox summary (sender, subject, date)
 

--- a/skills/gws-gmail-watch/SKILL.md
+++ b/skills/gws-gmail-watch/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # gmail +watch
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Watch for new emails and stream them as NDJSON
 

--- a/skills/gws-gmail/SKILL.md
+++ b/skills/gws-gmail/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # gmail (v1)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws gmail <resource> <method> [flags]

--- a/skills/gws-keep/SKILL.md
+++ b/skills/gws-keep/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # keep (v1)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws keep <resource> <method> [flags]

--- a/skills/gws-meet/SKILL.md
+++ b/skills/gws-meet/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # meet (v2)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws meet <resource> <method> [flags]

--- a/skills/gws-modelarmor-create-template/SKILL.md
+++ b/skills/gws-modelarmor-create-template/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # modelarmor +create-template
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Create a new Model Armor template
 

--- a/skills/gws-modelarmor-sanitize-prompt/SKILL.md
+++ b/skills/gws-modelarmor-sanitize-prompt/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # modelarmor +sanitize-prompt
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Sanitize a user prompt through a Model Armor template
 

--- a/skills/gws-modelarmor-sanitize-response/SKILL.md
+++ b/skills/gws-modelarmor-sanitize-response/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # modelarmor +sanitize-response
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Sanitize a model response through a Model Armor template
 

--- a/skills/gws-modelarmor/SKILL.md
+++ b/skills/gws-modelarmor/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # modelarmor (v1)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws modelarmor <resource> <method> [flags]

--- a/skills/gws-people/SKILL.md
+++ b/skills/gws-people/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # people (v1)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws people <resource> <method> [flags]

--- a/skills/gws-script-push/SKILL.md
+++ b/skills/gws-script-push/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # script +push
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Upload local files to an Apps Script project
 

--- a/skills/gws-script/SKILL.md
+++ b/skills/gws-script/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # script (v1)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws script <resource> <method> [flags]

--- a/skills/gws-sheets-append/SKILL.md
+++ b/skills/gws-sheets-append/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # sheets +append
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Append a row to a spreadsheet
 
@@ -30,7 +30,7 @@ gws sheets +append --spreadsheet <ID>
 | `--spreadsheet` | ✓ | — | Spreadsheet ID |
 | `--values` | — | — | Comma-separated values (simple strings) |
 | `--json-values` | — | — | JSON array of rows, e.g. '[["a","b"],["c","d"]]' |
-| `--range` | — | `A1` | Target range in A1 notation (e.g. 'Sheet2!A1') to select a specific tab |
+| `--range` | — | — | Target range in A1 notation (e.g. 'Sheet2!A1'). Defaults to 'A1' (first sheet) |
 
 ## Examples
 
@@ -44,7 +44,7 @@ gws sheets +append --spreadsheet ID --range "Sheet2!A1" --values 'Alice,100'
 
 - Use --values for simple single-row appends.
 - Use --json-values for bulk multi-row inserts.
-- Use --range to append to a specific sheet tab (default: A1, i.e. first sheet).
+- Use --range to target a specific sheet tab (default: A1, i.e. first sheet).
 
 > [!CAUTION]
 > This is a **write** command — confirm with the user before executing.

--- a/skills/gws-sheets-read/SKILL.md
+++ b/skills/gws-sheets-read/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # sheets +read
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Read values from a spreadsheet
 

--- a/skills/gws-sheets/SKILL.md
+++ b/skills/gws-sheets/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # sheets (v4)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws sheets <resource> <method> [flags]

--- a/skills/gws-slides/SKILL.md
+++ b/skills/gws-slides/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # slides (v1)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws slides <resource> <method> [flags]

--- a/skills/gws-tasks/SKILL.md
+++ b/skills/gws-tasks/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # tasks (v1)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws tasks <resource> <method> [flags]

--- a/skills/gws-workflow-email-to-task/SKILL.md
+++ b/skills/gws-workflow-email-to-task/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # workflow +email-to-task
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Convert a Gmail message into a Google Tasks entry
 

--- a/skills/gws-workflow-file-announce/SKILL.md
+++ b/skills/gws-workflow-file-announce/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # workflow +file-announce
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Announce a Drive file in a Chat space
 

--- a/skills/gws-workflow-meeting-prep/SKILL.md
+++ b/skills/gws-workflow-meeting-prep/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # workflow +meeting-prep
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Prepare for your next meeting: agenda, attendees, and linked docs
 

--- a/skills/gws-workflow-standup-report/SKILL.md
+++ b/skills/gws-workflow-standup-report/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # workflow +standup-report
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Today's meetings + open tasks as a standup summary
 

--- a/skills/gws-workflow-weekly-digest/SKILL.md
+++ b/skills/gws-workflow-weekly-digest/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # workflow +weekly-digest
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 Weekly summary: this week's meetings + unread email count
 

--- a/skills/gws-workflow/SKILL.md
+++ b/skills/gws-workflow/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # workflow (v1)
 
-> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If you're installing skills selectively, install `gws-shared` alongside this skill. If you're generating skills from a local checkout, run `gws generate-skills` to create it.
 
 ```bash
 gws workflow <resource> <method> [flags]


### PR DESCRIPTION
## Summary
- add `gws-shared` to the selective install examples in the README
- update generated prerequisite text so selective installs point to `gws-shared`, while local checkout flows still mention `gws generate-skills`
- regenerate the affected `skills/gws-*` docs and add a changeset

## Why
Issue #672 points out that service skills depend on `gws-shared`, but the current selective install examples omit it. The generated prerequisite text also only mentions `gws generate-skills`, which is right for local development but not for people installing a small subset from GitHub.

## Verification
- `cargo test -p google-workspace-cli prerequisite_mentions_selective_install`
- `cargo run -q -p google-workspace-cli -- generate-skills --output-dir skills`

Addresses #672.
