### PR TITLE
fix(auth): include contacts and gmail settings scopes in login options

### DIFF
--- a/.changeset/auth-scope-picker-contacts-gmail-settings.md
+++ b/.changeset/auth-scope-picker-contacts-gmail-settings.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Include Google Contacts and Gmail settings scopes in full login scopes and fallback scope picker entries.

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -289,9 +289,11 @@ pub const FULL_SCOPES: &[&str] = &[
     "https://www.googleapis.com/auth/drive",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.settings.basic",
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/documents",
     "https://www.googleapis.com/auth/presentations",
+    "https://www.googleapis.com/auth/contacts",
     "https://www.googleapis.com/auth/tasks",
     "https://www.googleapis.com/auth/pubsub",
     "https://www.googleapis.com/auth/cloud-platform",
@@ -1550,6 +1552,14 @@ const SCOPE_ENTRIES: &[ScopeEntry] = &[
         label: "Gmail",
     },
     ScopeEntry {
+        scope: "https://www.googleapis.com/auth/gmail.settings.basic",
+        label: "Gmail Settings",
+    },
+    ScopeEntry {
+        scope: "https://www.googleapis.com/auth/contacts",
+        label: "Google Contacts",
+    },
+    ScopeEntry {
         scope: "https://www.googleapis.com/auth/calendar",
         label: "Google Calendar",
     },
@@ -1789,6 +1799,15 @@ mod tests {
     fn resolve_scopes_full_returns_full_scopes() {
         let scopes = run_resolve_scopes(ScopeMode::Full, None);
         assert_eq!(scopes.len(), FULL_SCOPES.len());
+        assert!(scopes.contains(&"https://www.googleapis.com/auth/gmail.settings.basic".to_string()));
+        assert!(scopes.contains(&"https://www.googleapis.com/auth/contacts".to_string()));
+    }
+
+    #[test]
+    fn scope_entries_include_contacts_and_gmail_settings_basic() {
+        let scope_entries: Vec<&str> = SCOPE_ENTRIES.iter().map(|entry| entry.scope).collect();
+        assert!(scope_entries.contains(&"https://www.googleapis.com/auth/gmail.settings.basic"));
+        assert!(scope_entries.contains(&"https://www.googleapis.com/auth/contacts"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add https://www.googleapis.com/auth/gmail.settings.basic and https://www.googleapis.com/auth/contacts to FULL_SCOPES so non-interactive --full logins can request required write scopes
- add both scopes to the fallback static scope picker entries so auth login without project discovery can still select them
- add tests asserting the full scope set and static picker scope catalog include these two scopes, and add a patch changeset

Fixes #668
Fixes #673