### PR TITLE
fix(auth): ensure proxy OAuth URL includes response_type cleanly

### DIFF
--- a/.changeset/fix-proxy-auth-url-response-type.md
+++ b/.changeset/fix-proxy-auth-url-response-type.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Fix OAuth proxy login URL formatting so `response_type=code` is reliably preserved in authorization requests.

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -75,13 +75,7 @@ async fn exchange_code_with_reqwest(
 fn build_proxy_auth_url(client_id: &str, redirect_uri: &str, scopes: &[String]) -> String {
     let scopes_str = scopes.join(" ");
     format!(
-        "https://accounts.google.com/o/oauth2/auth?\
-         scope={}&\
-         access_type=offline&\
-         redirect_uri={}&\
-         response_type=code&\
-         client_id={}&\
-         prompt=select_account+consent",
+        "https://accounts.google.com/o/oauth2/auth?scope={}&access_type=offline&redirect_uri={}&response_type=code&client_id={}&prompt=select_account+consent",
         urlencoding(&scopes_str),
         urlencoding(redirect_uri),
         urlencoding(client_id)
@@ -2495,6 +2489,9 @@ mod tests {
             "scope={}",
             urlencoding("https://www.googleapis.com/auth/drive openid")
         )));
+        assert!(url.contains("response_type=code"));
+        assert!(!url.contains("%20response_type"));
+        assert!(!url.contains(" response_type"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- remove whitespace artifacts from the manually constructed proxy OAuth authorization URL so query parameter keys are emitted exactly as expected
- ensure `response_type=code` is always present and not prefixed by encoded/leading spaces when proxy login flow is used
- extend unit coverage for `build_proxy_auth_url` to assert clean `response_type` formatting and include a patch changeset

Fixes #695