### PR TITLE
fix(security): validate resource IDs in docs, sheets, calendar, and drive helpers

### DIFF
--- a/.changeset/validate-resource-ids-in-helpers.md
+++ b/.changeset/validate-resource-ids-in-helpers.md
@@ -1,0 +1,11 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Validate resource IDs in docs, sheets, calendar, and drive helpers
+
+`document_id` (docs `+write`), `spreadsheet_id` (sheets `+append` and `+read`),
+`calendar_id` (calendar `+insert`), and `parent_id` (drive `+upload`) are now
+validated with `validate_resource_name()` before use. This rejects path traversal
+segments (`../`), control characters, and URL-special characters (`?`, `#`, `%`)
+that could be injected by adversarial AI-agent inputs.

--- a/crates/google-workspace-cli/src/helpers/calendar.rs
+++ b/crates/google-workspace-cli/src/helpers/calendar.rs
@@ -423,8 +423,7 @@ fn build_insert_request(
     matches: &ArgMatches,
     doc: &crate::discovery::RestDescription,
 ) -> Result<(String, String, Vec<String>), GwsError> {
-    let calendar_id =
-        crate::validate::validate_resource_name(matches.get_one::<String>("calendar").unwrap())?;
+    let calendar_id = matches.get_one::<String>("calendar").unwrap();
     let summary = matches.get_one::<String>("summary").unwrap();
     let start = matches.get_one::<String>("start").unwrap();
     let end = matches.get_one::<String>("end").unwrap();

--- a/crates/google-workspace-cli/src/helpers/calendar.rs
+++ b/crates/google-workspace-cli/src/helpers/calendar.rs
@@ -423,7 +423,8 @@ fn build_insert_request(
     matches: &ArgMatches,
     doc: &crate::discovery::RestDescription,
 ) -> Result<(String, String, Vec<String>), GwsError> {
-    let calendar_id = matches.get_one::<String>("calendar").unwrap();
+    let calendar_id =
+        crate::validate::validate_resource_name(matches.get_one::<String>("calendar").unwrap())?;
     let summary = matches.get_one::<String>("summary").unwrap();
     let start = matches.get_one::<String>("start").unwrap();
     let end = matches.get_one::<String>("end").unwrap();
@@ -574,6 +575,26 @@ mod tests {
         assert!(body.contains("Meeting"));
         assert!(body.contains("2024-01-01T10:00:00Z"));
         assert_eq!(scopes[0], "https://scope");
+    }
+
+    #[test]
+    fn test_build_insert_request_rejects_traversal_calendar_id() {
+        let doc = make_mock_doc();
+        let matches = make_matches_insert(&[
+            "test",
+            "--calendar",
+            "../../.ssh/id_rsa",
+            "--summary",
+            "X",
+            "--start",
+            "2024-01-01T10:00:00Z",
+            "--end",
+            "2024-01-01T11:00:00Z",
+        ]);
+        assert!(
+            build_insert_request(&matches, &doc).is_err(),
+            "path traversal in --calendar must be rejected"
+        );
     }
 
     #[test]

--- a/crates/google-workspace-cli/src/helpers/calendar.rs
+++ b/crates/google-workspace-cli/src/helpers/calendar.rs
@@ -423,7 +423,8 @@ fn build_insert_request(
     matches: &ArgMatches,
     doc: &crate::discovery::RestDescription,
 ) -> Result<(String, String, Vec<String>), GwsError> {
-    let calendar_id = matches.get_one::<String>("calendar").unwrap();
+    let calendar_id =
+        crate::validate::validate_resource_name(matches.get_one::<String>("calendar").unwrap())?;
     let summary = matches.get_one::<String>("summary").unwrap();
     let start = matches.get_one::<String>("start").unwrap();
     let end = matches.get_one::<String>("end").unwrap();

--- a/crates/google-workspace-cli/src/helpers/docs.rs
+++ b/crates/google-workspace-cli/src/helpers/docs.rs
@@ -120,7 +120,8 @@ fn build_write_request(
     matches: &ArgMatches,
     doc: &crate::discovery::RestDescription,
 ) -> Result<(String, String, Vec<String>), GwsError> {
-    let document_id = matches.get_one::<String>("document").unwrap();
+    let document_id =
+        crate::validate::validate_resource_name(matches.get_one::<String>("document").unwrap())?;
     let text = matches.get_one::<String>("text").unwrap();
 
     let documents_res = doc
@@ -202,5 +203,21 @@ mod tests {
         assert!(body.contains("hello world"));
         assert!(body.contains("endOfSegmentLocation"));
         assert_eq!(scopes[0], "https://scope");
+    }
+
+    #[test]
+    fn test_build_write_request_rejects_traversal_document_id() {
+        let doc = make_mock_doc();
+        let matches = make_matches_write(&["test", "--document", "../../.ssh/id_rsa", "--text", "x"]);
+        let result = build_write_request(&matches, &doc);
+        assert!(result.is_err(), "path traversal in --document must be rejected");
+    }
+
+    #[test]
+    fn test_build_write_request_rejects_query_injection_document_id() {
+        let doc = make_mock_doc();
+        let matches = make_matches_write(&["test", "--document", "abc?evil=1", "--text", "x"]);
+        let result = build_write_request(&matches, &doc);
+        assert!(result.is_err(), "'?' in --document must be rejected");
     }
 }

--- a/crates/google-workspace-cli/src/helpers/drive.rs
+++ b/crates/google-workspace-cli/src/helpers/drive.rs
@@ -148,7 +148,7 @@ fn build_metadata(filename: &str, parent_id: Option<&str>) -> Result<Value, GwsE
     });
 
     if let Some(parent) = parent_id {
-        crate::validate::validate_resource_name(parent)?;
+        let parent = crate::validate::validate_resource_name(parent)?;
         metadata["parents"] = json!([parent]);
     }
 

--- a/crates/google-workspace-cli/src/helpers/drive.rs
+++ b/crates/google-workspace-cli/src/helpers/drive.rs
@@ -91,7 +91,7 @@ TIPS:
                 })?;
 
                 // Build metadata
-                let metadata = build_metadata(&filename, parent_id.map(|s| s.as_str()));
+                let metadata = build_metadata(&filename, parent_id.map(|s| s.as_str()))?;
 
                 let body_str = metadata.to_string();
 
@@ -142,16 +142,17 @@ fn determine_filename(file_path: &str, name_arg: Option<&str>) -> Result<String,
     }
 }
 
-fn build_metadata(filename: &str, parent_id: Option<&str>) -> Value {
+fn build_metadata(filename: &str, parent_id: Option<&str>) -> Result<Value, GwsError> {
     let mut metadata = json!({
         "name": filename
     });
 
     if let Some(parent) = parent_id {
+        crate::validate::validate_resource_name(parent)?;
         metadata["parents"] = json!([parent]);
     }
 
-    metadata
+    Ok(metadata)
 }
 
 #[cfg(test)]
@@ -182,15 +183,31 @@ mod tests {
 
     #[test]
     fn test_build_metadata_no_parent() {
-        let meta = build_metadata("file.txt", None);
+        let meta = build_metadata("file.txt", None).unwrap();
         assert_eq!(meta["name"], "file.txt");
         assert!(meta.get("parents").is_none());
     }
 
     #[test]
     fn test_build_metadata_with_parent() {
-        let meta = build_metadata("file.txt", Some("folder123"));
+        let meta = build_metadata("file.txt", Some("folder123")).unwrap();
         assert_eq!(meta["name"], "file.txt");
         assert_eq!(meta["parents"][0], "folder123");
+    }
+
+    #[test]
+    fn test_build_metadata_rejects_traversal_parent_id() {
+        assert!(
+            build_metadata("file.txt", Some("../../.ssh/id_rsa")).is_err(),
+            "path traversal in --parent must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_build_metadata_rejects_query_injection_parent_id() {
+        assert!(
+            build_metadata("file.txt", Some("folder?evil=1")).is_err(),
+            "'?' in --parent must be rejected"
+        );
     }
 }

--- a/crates/google-workspace-cli/src/helpers/sheets.rs
+++ b/crates/google-workspace-cli/src/helpers/sheets.rs
@@ -210,6 +210,7 @@ fn build_append_request(
     doc: &crate::discovery::RestDescription,
 ) -> Result<(String, String, Vec<String>), GwsError> {
     crate::validate::validate_resource_name(&config.spreadsheet_id)?;
+    crate::validate::validate_resource_name(&config.range)?;
 
     let spreadsheets_res = doc
         .resources
@@ -243,6 +244,7 @@ fn build_read_request(
     doc: &crate::discovery::RestDescription,
 ) -> Result<(String, Vec<String>), GwsError> {
     crate::validate::validate_resource_name(&config.spreadsheet_id)?;
+    crate::validate::validate_resource_name(&config.range)?;
 
     // ... resource lookup omitted for brevity ...
     let spreadsheets_res = doc

--- a/crates/google-workspace-cli/src/helpers/sheets.rs
+++ b/crates/google-workspace-cli/src/helpers/sheets.rs
@@ -209,6 +209,8 @@ fn build_append_request(
     config: &AppendConfig,
     doc: &crate::discovery::RestDescription,
 ) -> Result<(String, String, Vec<String>), GwsError> {
+    crate::validate::validate_resource_name(&config.spreadsheet_id)?;
+
     let spreadsheets_res = doc
         .resources
         .get("spreadsheets")
@@ -240,6 +242,8 @@ fn build_read_request(
     config: &ReadConfig,
     doc: &crate::discovery::RestDescription,
 ) -> Result<(String, Vec<String>), GwsError> {
+    crate::validate::validate_resource_name(&config.spreadsheet_id)?;
+
     // ... resource lookup omitted for brevity ...
     let spreadsheets_res = doc
         .resources
@@ -308,6 +312,7 @@ pub fn parse_append_args(matches: &ArgMatches) -> AppendConfig {
         values,
     }
 }
+
 
 /// Configuration for reading values from a spreadsheet.
 pub struct ReadConfig {
@@ -521,5 +526,32 @@ mod tests {
         let subcommands: Vec<_> = cmd.get_subcommands().map(|s| s.get_name()).collect();
         assert!(subcommands.contains(&"+append"));
         assert!(subcommands.contains(&"+read"));
+    }
+
+    #[test]
+    fn test_build_append_request_rejects_traversal() {
+        let doc = make_mock_doc();
+        let config = AppendConfig {
+            spreadsheet_id: "../../.ssh/id_rsa".to_string(),
+            range: "A1".to_string(),
+            values: vec![vec!["x".to_string()]],
+        };
+        assert!(
+            build_append_request(&config, &doc).is_err(),
+            "path traversal in spreadsheet ID must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_build_read_request_rejects_query_injection() {
+        let doc = make_mock_doc();
+        let config = ReadConfig {
+            spreadsheet_id: "abc?evil=1".to_string(),
+            range: "A1:B2".to_string(),
+        };
+        assert!(
+            build_read_request(&config, &doc).is_err(),
+            "'?' in spreadsheet ID must be rejected"
+        );
     }
 }

--- a/crates/google-workspace-cli/src/helpers/sheets.rs
+++ b/crates/google-workspace-cli/src/helpers/sheets.rs
@@ -209,8 +209,7 @@ fn build_append_request(
     config: &AppendConfig,
     doc: &crate::discovery::RestDescription,
 ) -> Result<(String, String, Vec<String>), GwsError> {
-    crate::validate::validate_resource_name(&config.spreadsheet_id)?;
-    crate::validate::validate_resource_name(&config.range)?;
+    let spreadsheet_id = crate::validate::validate_resource_name(&config.spreadsheet_id)?;
 
     let spreadsheets_res = doc
         .resources
@@ -224,7 +223,7 @@ fn build_append_request(
     })?;
 
     let params = json!({
-        "spreadsheetId": config.spreadsheet_id,
+        "spreadsheetId": spreadsheet_id,
         "range": config.range,
         "valueInputOption": "USER_ENTERED"
     });
@@ -243,8 +242,7 @@ fn build_read_request(
     config: &ReadConfig,
     doc: &crate::discovery::RestDescription,
 ) -> Result<(String, Vec<String>), GwsError> {
-    crate::validate::validate_resource_name(&config.spreadsheet_id)?;
-    crate::validate::validate_resource_name(&config.range)?;
+    let spreadsheet_id = crate::validate::validate_resource_name(&config.spreadsheet_id)?;
 
     // ... resource lookup omitted for brevity ...
     let spreadsheets_res = doc
@@ -259,7 +257,7 @@ fn build_read_request(
     })?;
 
     let params = json!({
-        "spreadsheetId": config.spreadsheet_id,
+        "spreadsheetId": spreadsheet_id,
         "range": config.range
     });
 


### PR DESCRIPTION
## Description

Adds `validate_resource_name()` calls before embedding user-supplied IDs in API request parameters for four helpers that were missing this check. This is required by the [AGENTS.md security checklist](../main/AGENTS.md#checklist-for-new-features):

> **Resource names** (project IDs, space names, topic names) → Use `validate_resource_name()`

**Affected helpers:**
- `docs +write` — `--document` ID embedded in `batchUpdate` params
- `sheets +append` and `+read` — `--spreadsheet` ID embedded in `values.append`/`values.get` params
- `calendar +insert` — `--calendar` ID embedded in `events.insert` params
- `drive +upload` — `--parent` folder ID embedded in `files.create` metadata body

`validate_resource_name()` rejects path traversal segments (`..`), control characters, and URL-special characters (`?`, `#`, `%`) that could be injected by adversarial AI-agent inputs.

**Dry Run Output:**
```json
// Not applicable — this is a security hardening fix with no API call changes.
// The validation happens before the request is built.
```

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [ ] I have run `cargo fmt --all` to format the code perfectly.
- [ ] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.