### PR TITLE
docs(skills): guide agents to use Sheets/Docs/Slides APIs for content creation

### DIFF
--- a/.changeset/drive-skill-content-creation-guidance.md
+++ b/.changeset/drive-skill-content-creation-guidance.md
@@ -1,0 +1,9 @@
+---
+"@googleworkspace/cli": patch
+---
+
+docs(skills): add content creation guidance to gws-drive SKILL.md
+
+Point agents to the Sheets, Docs, and Slides APIs when creating files with
+content. `drive files create` with a Google MIME type produces an empty shell;
+the guidance prevents agents from silently losing data.

--- a/skills/gws-drive/SKILL.md
+++ b/skills/gws-drive/SKILL.md
@@ -27,13 +27,15 @@ gws drive <resource> <method> [flags]
 
 ## Content Creation Guidance
 
-> **Important:** The Drive API cannot set cell values, document text, or slide content. Using `drive files create` with a Sheets, Docs, or Slides MIME type creates an empty shell file — use the service-specific APIs instead:
+> **Important:** The Drive API cannot set cell values, document text, or slide content. Using `drive files create` with a Sheets, Docs, or Slides MIME type creates an unreachable empty shell — use the service-specific APIs to create and populate content:
 >
-> | Goal | Command |
-> |------|---------|
-> | Create a spreadsheet with data | `gws sheets spreadsheets create` |
-> | Create a Google Doc with content | `gws docs documents create` |
-> | Create a Google Slides presentation | `gws slides presentations create` |
+> | Goal | Step 1 — create | Step 2 — write content |
+> |------|-----------------|----------------------|
+> | Spreadsheet | `gws sheets spreadsheets create` → returns `spreadsheetId` | `gws sheets spreadsheets values batchUpdate` |
+> | Google Doc | `gws docs documents create` → returns `documentId` | `gws docs documents batchUpdate` |
+> | Slides presentation | `gws slides presentations create` → returns `presentationId` | `gws slides presentations batchUpdate` |
+>
+> Note: the `create` calls for Docs and Slides also produce blank files; any content in the request body is ignored by those APIs. Always follow with a `batchUpdate` call to insert content.
 >
 > Only use `drive files create` when uploading binary/non-Google file types (e.g. PDF, PNG, CSV) or creating plain empty containers like folders.
 

--- a/skills/gws-drive/SKILL.md
+++ b/skills/gws-drive/SKILL.md
@@ -27,7 +27,7 @@ gws drive <resource> <method> [flags]
 
 ## Content Creation Guidance
 
-> **Important:** The Drive API cannot set cell values, document text, or slide content. Using `drive files create` with a Sheets, Docs, or Slides MIME type creates an unreachable empty shell — use the service-specific APIs to create and populate content:
+> **Important:** The Drive API cannot set cell values, document text, or slide content. Using `drive files create` with a Sheets, Docs, or Slides MIME type creates an empty shell — use the service-specific APIs to create and populate content:
 >
 > | Goal | Step 1 — create | Step 2 — write content |
 > |------|-----------------|----------------------|

--- a/skills/gws-drive/SKILL.md
+++ b/skills/gws-drive/SKILL.md
@@ -25,6 +25,18 @@ gws drive <resource> <method> [flags]
 |---------|-------------|
 | [`+upload`](../gws-drive-upload/SKILL.md) | Upload a file with automatic metadata |
 
+## Content Creation Guidance
+
+> **Important:** The Drive API cannot set cell values, document text, or slide content. Using `drive files create` with a Sheets, Docs, or Slides MIME type creates an empty shell file — use the service-specific APIs instead:
+>
+> | Goal | Command |
+> |------|---------|
+> | Create a spreadsheet with data | `gws sheets spreadsheets create` |
+> | Create a Google Doc with content | `gws docs documents create` |
+> | Create a Google Slides presentation | `gws slides presentations create` |
+>
+> Only use `drive files create` when uploading binary/non-Google file types (e.g. PDF, PNG, CSV) or creating plain empty containers like folders.
+
 ## API Resources
 
 ### about


### PR DESCRIPTION
## Problem

When an AI agent needs to create a Google Sheet, Slides presentation, or Doc, it loads `gws-drive` and calls `drive files create` with the appropriate MIME type. This creates an empty file shell — the Drive API cannot set cell values, document text, or slide content. The correct approach is to use the service-specific APIs (`sheets spreadsheets create`, `docs documents create`, `slides presentations create`), but nothing in the Drive skill mentions this.

Agents pick Drive because it's the first skill that looks relevant for "create a file", and silently produce empty files.

## Solution

Adds a **Content Creation Guidance** section to `skills/gws-drive/SKILL.md` immediately after the Helper Commands table. The section:

- Warns that `drive files create` with a Google MIME type produces an empty shell
- Provides a lookup table mapping the goal to the correct `gws` command
- Clarifies when `drive files create` is the right tool (binary/non-Google file types, folders)

Fixes #566