### PR TITLE
fix(services): add apps-script alias for the script service

### DIFF
--- a/.changeset/fix-script-apps-script-alias.md
+++ b/.changeset/fix-script-apps-script-alias.md
@@ -1,0 +1,10 @@
+---
+"@googleworkspace/cli": patch
+---
+
+fix(services): add apps-script alias for the script service
+
+`helpers/mod.rs` already routes `"apps-script"` to `ScriptHelper`, but the
+service registry only listed `"script"` as an alias, so `gws apps-script ...`
+returned "Unknown service". Adds `"apps-script"` to the registry so both
+aliases resolve identically.

--- a/crates/google-workspace/src/services.rs
+++ b/crates/google-workspace/src/services.rs
@@ -131,7 +131,7 @@ pub const SERVICES: &[ServiceEntry] = &[
         description: "Cross-service productivity workflows",
     },
     ServiceEntry {
-        aliases: &["script"],
+        aliases: &["script", "apps-script"],
         api_name: "script",
         version: "v1",
         description: "Manage Google Apps Script projects",
@@ -173,6 +173,18 @@ mod tests {
         assert_eq!(
             resolve_service("reports").unwrap(),
             ("admin".to_string(), "reports_v1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_service_script_aliases() {
+        assert_eq!(
+            resolve_service("script").unwrap(),
+            ("script".to_string(), "v1".to_string())
+        );
+        assert_eq!(
+            resolve_service("apps-script").unwrap(),
+            ("script".to_string(), "v1".to_string())
         );
     }
 


### PR DESCRIPTION
## Problem

`helpers/mod.rs` already routes `"apps-script"` to `ScriptHelper`:

```rust
"script" | "apps-script" => Some(Box::new(script::ScriptHelper)),
```

But the service registry (`services.rs`) only lists `"script"` as an alias:

```rust
aliases: &["script"],
```

So `gws apps-script ...` returns `Unknown service 'apps-script'` and all the
existing helper code is unreachable via that alias.

## Fix

Adds `"apps-script"` to the `aliases` array so `resolve_service("apps-script")`
resolves to `("script", "v1")`, consistent with what the helper router already
expects.

Also adds a test asserting both `"script"` and `"apps-script"` resolve to the
same service entry.

Fixes #625