### PR TITLE
fix(formatter): strip terminal escape sequences from non-JSON output

### DIFF
--- a/.changeset/fix-formatter-sanitize-terminal-escapes.md
+++ b/.changeset/fix-formatter-sanitize-terminal-escapes.md
@@ -1,0 +1,11 @@
+---
+"@googleworkspace/cli": patch
+---
+
+fix(formatter): strip terminal escape sequences from non-JSON output
+
+API responses may contain user-generated content with ANSI escape codes or
+other control characters. JSON output is safe because serde escapes them as
+\uXXXX, but table/CSV/YAML formats passed strings verbatim, allowing a
+malicious API value to inject terminal sequences. Adds strip_control_chars()
+which is applied to every string cell in value_to_cell().

--- a/crates/google-workspace-cli/src/formatter.rs
+++ b/crates/google-workspace-cli/src/formatter.rs
@@ -281,6 +281,7 @@ fn json_to_yaml(value: &Value, indent: usize) -> String {
         Value::Bool(b) => b.to_string(),
         Value::Number(n) => n.to_string(),
         Value::String(s) => {
+            let s = strip_control_chars(s);
             if s.contains('\n') {
                 // Genuine multi-line content: block scalar is the most readable choice.
                 format!(
@@ -425,15 +426,39 @@ fn csv_escape(s: &str) -> String {
 /// JSON output is safe because serde serialises control characters as `\uXXXX`,
 /// but table/CSV/YAML formats pass strings through verbatim, which would allow
 /// a malicious API value to inject terminal sequences into the user's terminal.
+///
+/// Sequences handled:
+/// - CSI  `ESC [` … final-byte          (SGR colours, cursor movement, …)
+/// - OSC  `ESC ]` … BEL or ST          (window title, hyperlinks, …)
+/// - DCS  `ESC P` … ST                 (device-control strings)
+/// - SOS  `ESC X` … ST                 (start-of-string)
+/// - PM   `ESC ^` … ST                 (privacy message)
+/// - APC  `ESC _` … ST                 (application-program command)
+/// - Other two-char Fe sequences        (`ESC` + 0x40–0x5F, not in the above)
+/// - Bare C0/C1 control characters      (NUL, BEL, BS, CR, …; tab/newline kept)
 fn strip_control_chars(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut chars = s.chars().peekable();
+
+    /// Consume chars until ST (BEL `\x07` or `ESC \`), used for OSC/DCS/SOS/PM/APC.
+    fn consume_until_st(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
+        while let Some(ch) = chars.next() {
+            if ch == '\x07' {
+                break;
+            }
+            if ch == '\x1b' {
+                chars.next(); // consume the `\` of ESC \
+                break;
+            }
+        }
+    }
+
     while let Some(c) = chars.next() {
         match c {
             // ESC-prefixed sequences: consume until the sequence terminator.
             '\x1b' => {
-                match chars.peek() {
-                    // CSI sequences: ESC [ ... <final byte 0x40–0x7E>
+                match chars.peek().copied() {
+                    // CSI: ESC [ … <final byte 0x40–0x7E>
                     Some('[') => {
                         chars.next();
                         for ch in chars.by_ref() {
@@ -442,21 +467,33 @@ fn strip_control_chars(s: &str) -> String {
                             }
                         }
                     }
-                    // OSC sequences: ESC ] ... ST (BEL or ESC \)
+                    // OSC: ESC ] … ST
                     Some(']') => {
                         chars.next();
-                        while let Some(ch) = chars.next() {
-                            if ch == '\x07' {
-                                break; // BEL string terminator
-                            }
-                            if ch == '\x1b' {
-                                chars.next(); // consume the \ of ESC \
-                                break;
-                            }
-                        }
+                        consume_until_st(&mut chars);
                     }
-                    // Other Fe sequences: ESC <0x40–0x5F> — consume one char.
-                    Some(&ch) if ('\x40'..='\x5f').contains(&ch) => {
+                    // DCS: ESC P … ST
+                    Some('P') => {
+                        chars.next();
+                        consume_until_st(&mut chars);
+                    }
+                    // SOS: ESC X … ST
+                    Some('X') => {
+                        chars.next();
+                        consume_until_st(&mut chars);
+                    }
+                    // PM: ESC ^ … ST
+                    Some('^') => {
+                        chars.next();
+                        consume_until_st(&mut chars);
+                    }
+                    // APC: ESC _ … ST
+                    Some('_') => {
+                        chars.next();
+                        consume_until_st(&mut chars);
+                    }
+                    // Other Fe two-char sequences: ESC <0x40–0x5F> — consume one char.
+                    Some(ch) if ('\x40'..='\x5f').contains(&ch) => {
                         chars.next();
                     }
                     _ => {}
@@ -721,9 +758,36 @@ mod tests {
     }
 
     #[test]
+    fn test_strip_control_chars_dcs_sequence() {
+        // DCS: ESC P … ST (BEL-terminated)
+        assert_eq!(strip_control_chars("\x1bPdcs-payload\x07clean"), "clean");
+        // DCS: ESC P … ST (ESC \-terminated)
+        assert_eq!(strip_control_chars("\x1bPdcs-payload\x1b\\clean"), "clean");
+    }
+
+    #[test]
+    fn test_strip_control_chars_sos_pm_apc_sequences() {
+        // SOS: ESC X … ST
+        assert_eq!(strip_control_chars("\x1bXsos-payload\x07clean"), "clean");
+        // PM: ESC ^ … ST
+        assert_eq!(strip_control_chars("\x1b^pm-payload\x07clean"), "clean");
+        // APC: ESC _ … ST
+        assert_eq!(strip_control_chars("\x1b_apc-payload\x07clean"), "clean");
+    }
+
+    #[test]
     fn test_value_to_cell_sanitizes_escape_sequences() {
         let val = Value::String("\x1b[31mred\x1b[0m".to_string());
         assert_eq!(value_to_cell(&val), "red");
+    }
+
+    #[test]
+    fn test_format_yaml_sanitizes_escape_sequences() {
+        // YAML strings must also be sanitized.
+        let val = json!({"title": "\x1b]0;injected\x07safe"});
+        let output = format_value(&val, &OutputFormat::Yaml);
+        assert!(output.contains("safe"));
+        assert!(!output.contains("\x1b"));
     }
 
     #[test]

--- a/crates/google-workspace-cli/src/formatter.rs
+++ b/crates/google-workspace-cli/src/formatter.rs
@@ -444,10 +444,12 @@ fn strip_control_chars(s: &str) -> String {
     fn consume_until_st(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
         while let Some(ch) = chars.next() {
             if ch == '\x07' {
-                break;
+                break; // BEL string terminator
             }
             if ch == '\x1b' {
-                chars.next(); // consume the `\` of ESC \
+                if let Some('\\') = chars.peek() {
+                    chars.next(); // consume the `\` of ESC \
+                }
                 break;
             }
         }

--- a/crates/google-workspace-cli/src/formatter.rs
+++ b/crates/google-workspace-cli/src/formatter.rs
@@ -418,10 +418,63 @@ fn csv_escape(s: &str) -> String {
     }
 }
 
+/// Strips ANSI/VT terminal escape sequences and C0/C1 control characters
+/// (except `\t` and `\n`) from a string.
+///
+/// API responses may contain user-generated content with embedded escape codes.
+/// JSON output is safe because serde serialises control characters as `\uXXXX`,
+/// but table/CSV/YAML formats pass strings through verbatim, which would allow
+/// a malicious API value to inject terminal sequences into the user's terminal.
+fn strip_control_chars(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            // ESC-prefixed sequences: consume until the sequence terminator.
+            '\x1b' => {
+                match chars.peek() {
+                    // CSI sequences: ESC [ ... <final byte 0x40–0x7E>
+                    Some('[') => {
+                        chars.next();
+                        for ch in chars.by_ref() {
+                            if ('\x40'..='\x7e').contains(&ch) {
+                                break;
+                            }
+                        }
+                    }
+                    // OSC sequences: ESC ] ... ST (BEL or ESC \)
+                    Some(']') => {
+                        chars.next();
+                        while let Some(ch) = chars.next() {
+                            if ch == '\x07' {
+                                break; // BEL string terminator
+                            }
+                            if ch == '\x1b' {
+                                chars.next(); // consume the \ of ESC \
+                                break;
+                            }
+                        }
+                    }
+                    // Other Fe sequences: ESC <0x40–0x5F> — consume one char.
+                    Some(&ch) if ('\x40'..='\x5f').contains(&ch) => {
+                        chars.next();
+                    }
+                    _ => {}
+                }
+            }
+            // Allow tab and newline; strip all other C0/C1 control characters.
+            '\t' | '\n' => out.push(c),
+            c if c.is_control() => {}
+            c => out.push(c),
+        }
+    }
+    out
+}
+
 fn value_to_cell(value: &Value) -> String {
     match value {
         Value::Null => String::new(),
-        Value::String(s) => s.clone(),
+        Value::String(s) => strip_control_chars(s),
         Value::Bool(b) => b.to_string(),
         Value::Number(n) => n.to_string(),
         Value::Array(arr) => {
@@ -627,6 +680,50 @@ mod tests {
         assert_eq!(csv_escape("simple"), "simple");
         assert_eq!(csv_escape("has,comma"), "\"has,comma\"");
         assert_eq!(csv_escape("has\"quote"), "\"has\"\"quote\"");
+    }
+
+    #[test]
+    fn test_strip_control_chars_clean_string() {
+        assert_eq!(strip_control_chars("hello world"), "hello world");
+        assert_eq!(strip_control_chars("tab\there"), "tab\there");
+        assert_eq!(strip_control_chars("line\nbreak"), "line\nbreak");
+    }
+
+    #[test]
+    fn test_strip_control_chars_csi_sequence() {
+        // SGR colour code: ESC [ 31 m
+        assert_eq!(strip_control_chars("\x1b[31mred\x1b[0m"), "red");
+        // Bold: ESC [ 1 m
+        assert_eq!(strip_control_chars("\x1b[1mbold\x1b[m"), "bold");
+    }
+
+    #[test]
+    fn test_strip_control_chars_osc_sequence() {
+        // OSC title injection: ESC ] 0 ; malicious BEL
+        assert_eq!(
+            strip_control_chars("\x1b]0;malicious\x07clean"),
+            "clean"
+        );
+        // OSC terminated by ESC \
+        assert_eq!(
+            strip_control_chars("\x1b]2;title\x1b\\clean"),
+            "clean"
+        );
+    }
+
+    #[test]
+    fn test_strip_control_chars_c0_control() {
+        // NUL, BEL, BS, CR stripped; tab and newline kept
+        assert_eq!(strip_control_chars("a\x00b"), "ab");
+        assert_eq!(strip_control_chars("a\x07b"), "ab");
+        assert_eq!(strip_control_chars("a\x08b"), "ab");
+        assert_eq!(strip_control_chars("a\rb"), "ab");
+    }
+
+    #[test]
+    fn test_value_to_cell_sanitizes_escape_sequences() {
+        let val = Value::String("\x1b[31mred\x1b[0m".to_string());
+        assert_eq!(value_to_cell(&val), "red");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`value_to_cell()` returns raw strings from API responses without sanitizing terminal escape sequences. Any response field containing ANSI escape codes (e.g. `\x1b]0;...`) renders them directly when using `--format table`, `--format yaml`, or `--format csv`.

JSON output (`--format json`) is safe because serde automatically escapes control characters as `\uXXXX`. Non-JSON formats pass untrusted content straight to the terminal, allowing an attacker to craft an API response value that injects terminal escape sequences — for example to set the window title, move the cursor, or trigger other VT sequences.

Raised in #635.

## Fix

Adds `strip_control_chars()` — a zero-dependency function that removes:

- **CSI sequences** (`ESC [ ... <final byte>`) — SGR colours, cursor movement, etc.
- **OSC sequences** (`ESC ] ... BEL` or `ESC ] ... ESC \`) — window title injection, hyperlinks, etc.
- **Other Fe two-char escape sequences** (`ESC <0x40–0x5F>`)
- **Bare C0/C1 control characters** — NUL, BEL, BS, CR, etc. (tab and newline are preserved)

`value_to_cell()` now calls `strip_control_chars()` for every `Value::String`, so all string fields rendered through `format_value()` in non-JSON modes are sanitized before output.

## Tests

- `test_strip_control_chars_clean_string` — passthrough for safe strings
- `test_strip_control_chars_csi_sequence` — SGR colour codes stripped
- `test_strip_control_chars_osc_sequence` — BEL- and ST-terminated OSC stripped
- `test_strip_control_chars_c0_control` — NUL, BEL, BS, CR stripped; tab/newline kept
- `test_value_to_cell_sanitizes_escape_sequences` — end-to-end through `value_to_cell`

Fixes #635