### PR TITLE
fix(services): add admin-directory alias for Admin SDK Directory API

### DIFF
--- a/.changeset/fix-admin-directory-alias.md
+++ b/.changeset/fix-admin-directory-alias.md
@@ -1,0 +1,10 @@
+---
+"@googleworkspace/cli": patch
+---
+
+fix(services): add admin-directory alias for the Admin SDK Directory API
+
+`gws admin-reports` implies audit/reporting, not user/group management.
+Adds `admin-directory` (and short form `directory`) as dedicated aliases for
+`admin/directory_v1`, making the Directory API discoverable without knowing
+the internal version string.

--- a/crates/google-workspace/src/services.rs
+++ b/crates/google-workspace/src/services.rs
@@ -59,6 +59,12 @@ pub const SERVICES: &[ServiceEntry] = &[
         description: "Audit logs and usage reports",
     },
     ServiceEntry {
+        aliases: &["admin-directory", "directory"],
+        api_name: "admin",
+        version: "directory_v1",
+        description: "Manage users, groups, and organizational units",
+    },
+    ServiceEntry {
         aliases: &["docs"],
         api_name: "docs",
         version: "v1",
@@ -173,6 +179,18 @@ mod tests {
         assert_eq!(
             resolve_service("reports").unwrap(),
             ("admin".to_string(), "reports_v1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_service_admin_directory_aliases() {
+        assert_eq!(
+            resolve_service("admin-directory").unwrap(),
+            ("admin".to_string(), "directory_v1".to_string())
+        );
+        assert_eq!(
+            resolve_service("directory").unwrap(),
+            ("admin".to_string(), "directory_v1".to_string())
         );
     }
 


### PR DESCRIPTION
## Problem

The Admin SDK Directory API (`admin/directory_v1`) is one of the most commonly used Google Workspace APIs for managing users, groups, and OUs. Accessing it currently requires the unintuitive command:

```bash
gws admin-reports --api-version directory_v1 users list --params '{"domain":"example.com"}'
```

`admin-reports` implies audit/usage reporting, not directory management. The version override syntax is also non-obvious and not documented anywhere prominent.

## Fix

Adds `admin-directory` and `directory` as first-class aliases for `(admin, directory_v1)` in the service registry:

```bash
# After this change:
gws admin-directory users list --params '{"domain":"example.com"}'
gws admin-directory groups list --params '{"domain":"example.com"}'
gws admin-directory members list --params '{"groupKey":"group@example.com"}'
gws directory orgunits list --params '{"customerId":"my_customer"}'
```

The existing `admin-reports` / `reports` aliases are unchanged.

Adds unit tests asserting both `admin-directory` and `directory` resolve to `("admin", "directory_v1")`.

Fixes #473