### PR TITLE
docs(drive): add shared drives tip to SKILL.md

### DIFF
--- a/.changeset/docs-drive-shared-drives-tip.md
+++ b/.changeset/docs-drive-shared-drives-tip.md
@@ -1,0 +1,11 @@
+---
+"@googleworkspace/cli": patch
+---
+
+docs(drive): add shared drives tip to SKILL.md
+
+Files in shared drives are invisible to `files list` and `files get`
+by default. Adds a "Shared Drives" section explaining that agents
+should retry with `supportsAllDrives: true` and
+`includeItemsFromAllDrives: true` when a file search returns no
+results and the user indicates the file is in a shared drive.

--- a/skills/gws-drive/SKILL.md
+++ b/skills/gws-drive/SKILL.md
@@ -27,7 +27,7 @@ gws drive <resource> <method> [flags]
 
 ## Shared Drives
 
-Files stored in a shared drive are not returned by default. If a file search returns no results, add "supportsAllDrives": true to your --params:
+Files stored in a shared drive are not returned by default. If a file search returns no results, add `"supportsAllDrives": true` to your `--params`:
 
 ```bash
 # List files across all drives (including shared drives)
@@ -37,7 +37,7 @@ gws drive files list --params '{"q":"name = '\''report.pdf'\''","supportsAllDriv
 gws drive files get --params '{"fileId":"FILE_ID","supportsAllDrives":true}'
 ```
 
-> **Tip:** If you can't find a file and the user mentions it's in a shared drive, retry the request with "supportsAllDrives": true (and "includeItemsFromAllDrives": true for list requests).
+> **Tip:** If you can't find a file and the user mentions it's in a shared drive, retry the request with `"supportsAllDrives": true` (and `"includeItemsFromAllDrives": true` for list/search requests only — this parameter is not valid for `files.get`).
 
 ## API Resources
 

--- a/skills/gws-drive/SKILL.md
+++ b/skills/gws-drive/SKILL.md
@@ -37,7 +37,7 @@ gws drive files list --params '{"q":"name = '\''report.pdf'\''","supportsAllDriv
 gws drive files get --params '{"fileId":"FILE_ID","supportsAllDrives":true}'
 ```
 
-> **Tip:** If you can't find a file and the user mentions it's in a shared drive, retry the request with `supportsAllDrives: true` and `includeItemsFromAllDrives: true`.
+> **Tip:** If you can't find a file and the user mentions it's in a shared drive, retry the request with "supportsAllDrives": true (and "includeItemsFromAllDrives": true for list requests).
 
 ## API Resources
 

--- a/skills/gws-drive/SKILL.md
+++ b/skills/gws-drive/SKILL.md
@@ -25,6 +25,20 @@ gws drive <resource> <method> [flags]
 |---------|-------------|
 | [`+upload`](../gws-drive-upload/SKILL.md) | Upload a file with automatic metadata |
 
+## Shared Drives
+
+Files stored in a shared drive are not returned by default. If a file search returns no results, add `supportsAllDrives=true` to your `--params`:
+
+```bash
+# List files across all drives (including shared drives)
+gws drive files list --params '{"q":"name = '\''report.pdf'\''","supportsAllDrives":true,"includeItemsFromAllDrives":true}'
+
+# Get a file that lives in a shared drive
+gws drive files get --params '{"fileId":"FILE_ID","supportsAllDrives":true}'
+```
+
+> **Tip:** If you can't find a file and the user mentions it's in a shared drive, retry the request with `supportsAllDrives: true` and `includeItemsFromAllDrives: true`.
+
 ## API Resources
 
 ### about

--- a/skills/gws-drive/SKILL.md
+++ b/skills/gws-drive/SKILL.md
@@ -27,7 +27,7 @@ gws drive <resource> <method> [flags]
 
 ## Shared Drives
 
-Files stored in a shared drive are not returned by default. If a file search returns no results, add `supportsAllDrives=true` to your `--params`:
+Files stored in a shared drive are not returned by default. If a file search returns no results, add "supportsAllDrives": true to your --params:
 
 ```bash
 # List files across all drives (including shared drives)


### PR DESCRIPTION
## Summary

Closes #327

Files stored in a shared drive are invisible to `files list` and `files get` by default. Agents searching for a file have no indication that they should retry with `supportsAllDrives: true`, causing unnecessary back-and-forth with the user.

This PR adds a **Shared Drives** section to `skills/gws-drive/SKILL.md` that:
- Explains the default behaviour (shared drive files excluded)
- Shows concrete examples with `supportsAllDrives: true` and `includeItemsFromAllDrives: true`
- Adds a tip so agents know to retry automatically when the user mentions a shared drive

## Changes

- `skills/gws-drive/SKILL.md` — new "Shared Drives" section with examples
- `.changeset/docs-drive-shared-drives-tip.md` — patch changeset