### PR TITLE
docs(recipes): replace stale --document-id examples with --document

### DIFF
--- a/.changeset/fix-docs-write-document-flag.md
+++ b/.changeset/fix-docs-write-document-flag.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Fix recipe examples that still use `gws docs +write --document-id`; the helper now expects `--document`.

--- a/crates/google-workspace-cli/registry/recipes.toml
+++ b/crates/google-workspace-cli/registry/recipes.toml
@@ -69,7 +69,7 @@ services = [ "drive", "docs" ]
 steps = [
   "Copy the template: `gws drive files copy --params '{\"fileId\": \"TEMPLATE_DOC_ID\"}' --json '{\"name\": \"Project Brief - Q2 Launch\"}'`",
   "Get the new doc ID from the response",
-  "Add content: `gws docs +write --document-id NEW_DOC_ID --text '## Project: Q2 Launch\n\n### Objective\nLaunch the new feature by end of Q2.'`",
+  "Add content: `gws docs +write --document NEW_DOC_ID --text '## Project: Q2 Launch\n\n### Objective\nLaunch the new feature by end of Q2.'`",
   "Share with team: `gws drive permissions create --params '{\"fileId\": \"NEW_DOC_ID\"}' --json '{\"role\": \"writer\", \"type\": \"user\", \"emailAddress\": \"team@company.com\"}'`"
 ]
 
@@ -443,7 +443,7 @@ steps = [
   "Find the message: `gws gmail users messages list --params '{\"userId\": \"me\", \"q\": \"subject:important from:boss@company.com\"}' --format table`",
   "Get message content: `gws gmail users messages get --params '{\"userId\": \"me\", \"id\": \"MSG_ID\"}'`",
   "Create a doc with the content: `gws docs documents create --json '{\"title\": \"Saved Email - Important Update\"}'`",
-  "Write the email body: `gws docs +write --document-id DOC_ID --text 'From: boss@company.com\nSubject: Important Update\n\n[EMAIL BODY]'`"
+  "Write the email body: `gws docs +write --document DOC_ID --text 'From: boss@company.com\nSubject: Important Update\n\n[EMAIL BODY]'`"
 ]
 
 [[recipes]]
@@ -491,6 +491,6 @@ services = [ "sheets", "docs", "drive" ]
 steps = [
   "Read the data: `gws sheets +read --spreadsheet SHEET_ID --range \"Sales!A1:D\"`",
   "Create the report doc: `gws docs documents create --json '{\"title\": \"Sales Report - January 2025\"}'`",
-  "Write the report: `gws docs +write --document-id DOC_ID --text '## Sales Report - January 2025\n\n### Summary\nTotal deals: 45\nRevenue: $125,000\n\n### Top Deals\n1. Acme Corp - $25,000\n2. Widget Inc - $18,000'`",
+  "Write the report: `gws docs +write --document DOC_ID --text '## Sales Report - January 2025\n\n### Summary\nTotal deals: 45\nRevenue: $125,000\n\n### Top Deals\n1. Acme Corp - $25,000\n2. Widget Inc - $18,000'`",
   "Share with stakeholders: `gws drive permissions create --params '{\"fileId\": \"DOC_ID\"}' --json '{\"role\": \"reader\", \"type\": \"user\", \"emailAddress\": \"cfo@company.com\"}'`"
 ]

--- a/skills/recipe-create-doc-from-template/SKILL.md
+++ b/skills/recipe-create-doc-from-template/SKILL.md
@@ -24,7 +24,7 @@ Copy a Google Docs template, fill in content, and share with collaborators.
 
 1. Copy the template: `gws drive files copy --params '{"fileId": "TEMPLATE_DOC_ID"}' --json '{"name": "Project Brief - Q2 Launch"}'`
 2. Get the new doc ID from the response
-3. Add content: `gws docs +write --document-id NEW_DOC_ID --text '## Project: Q2 Launch
+3. Add content: `gws docs +write --document NEW_DOC_ID --text '## Project: Q2 Launch
 
 ### Objective
 Launch the new feature by end of Q2.'`

--- a/skills/recipe-generate-report-from-sheet/SKILL.md
+++ b/skills/recipe-generate-report-from-sheet/SKILL.md
@@ -25,7 +25,7 @@ Read data from a Google Sheet and create a formatted Google Docs report.
 
 1. Read the data: `gws sheets +read --spreadsheet SHEET_ID --range "Sales!A1:D"`
 2. Create the report doc: `gws docs documents create --json '{"title": "Sales Report - January 2025"}'`
-3. Write the report: `gws docs +write --document-id DOC_ID --text '## Sales Report - January 2025
+3. Write the report: `gws docs +write --document DOC_ID --text '## Sales Report - January 2025
 
 ### Summary
 Total deals: 45

--- a/skills/recipe-save-email-to-doc/SKILL.md
+++ b/skills/recipe-save-email-to-doc/SKILL.md
@@ -25,7 +25,7 @@ Save a Gmail message body into a Google Doc for archival or reference.
 1. Find the message: `gws gmail users messages list --params '{"userId": "me", "q": "subject:important from:boss@company.com"}' --format table`
 2. Get message content: `gws gmail users messages get --params '{"userId": "me", "id": "MSG_ID"}'`
 3. Create a doc with the content: `gws docs documents create --json '{"title": "Saved Email - Important Update"}'`
-4. Write the email body: `gws docs +write --document-id DOC_ID --text 'From: boss@company.com
+4. Write the email body: `gws docs +write --document DOC_ID --text 'From: boss@company.com
 Subject: Important Update
 
 [EMAIL BODY]'`


### PR DESCRIPTION
## Bug Description

Recipe docs still instruct users to run `gws docs +write --document-id ...`, but the live helper and source both expect `--document`.

## Root Cause

The `docs +write` helper uses `.long("document")` in `crates/google-workspace-cli/src/helpers/docs.rs`, but three recipe skills and their mirrored registry entries were left on the stale `--document-id` spelling.

## Fix

- update all stale `docs +write` recipe examples from `--document-id` to `--document`
- cover the three affected recipe skills plus their mirrored registry entries
- add the required patch changeset

## How to Verify

1. Run `gws docs +write --help` and confirm the usage shows `--document <ID>`.
2. Run `git grep -n "document-id"` and confirm it returns no hits.
3. Spot-check the updated recipe skills and `crates/google-workspace-cli/registry/recipes.toml`.

Verification evidence from live CLI help:

```text
Usage: gws +write [OPTIONS] --document <ID> --text <TEXT>
```

## Test Plan

- [ ] Added regression test for this bug
- [x] Existing tests still pass or are unnecessary for this docs-only fix
- [x] Manual verification of the fix

## Risk Assessment

Low — documentation/recipe example fix only, no CLI behavior changes.
