### PR TITLE
Add recipe-apply-filter-to-existing-emails

### DIFF
--- a/.changeset/recipe-apply-filter-to-existing-emails.md
+++ b/.changeset/recipe-apply-filter-to-existing-emails.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Add `recipe-apply-filter-to-existing-emails` skill for applying a Gmail filter's actions to existing messages — the API equivalent of the UI's "also apply to matching conversations" checkbox.

--- a/crates/google-workspace-cli/registry/recipes.toml
+++ b/crates/google-workspace-cli/registry/recipes.toml
@@ -494,3 +494,17 @@ steps = [
   "Write the report: `gws docs +write --document-id DOC_ID --text '## Sales Report - January 2025\n\n### Summary\nTotal deals: 45\nRevenue: $125,000\n\n### Top Deals\n1. Acme Corp - $25,000\n2. Widget Inc - $18,000'`",
   "Share with stakeholders: `gws drive permissions create --params '{\"fileId\": \"DOC_ID\"}' --json '{\"role\": \"reader\", \"type\": \"user\", \"emailAddress\": \"cfo@company.com\"}'`"
 ]
+
+[[recipes]]
+name = "apply-filter-to-existing-emails"
+title = "Apply a Gmail Filter to Existing Messages"
+description = "Apply a Gmail filter's actions to existing messages (API equivalent of the UI 'apply to matching conversations' box)."
+category = "productivity"
+services = [ "gmail" ]
+steps = [
+  "Read the filter's criteria and action: `gws gmail users settings filters get --params '{\"userId\": \"me\", \"id\": \"FILTER_ID\"}'`",
+  "List matching messages, translating the criteria to a Gmail query (e.g. `subject:\"...\"`, `from:...`): `gws gmail users messages list --params '{\"userId\": \"me\", \"q\": \"subject:\\\"invoice\\\" in:anywhere\", \"maxResults\": 500}'`",
+  "Apply the filter's actions in bulk: `gws gmail users messages batchModify --params '{\"userId\": \"me\"}' --json '{\"ids\": [\"MSG_ID_1\", \"MSG_ID_2\"], \"addLabelIds\": [\"LABEL_ID\"], \"removeLabelIds\": [\"INBOX\", \"UNREAD\"]}'`",
+  "Verify the inbox is clear of matches: `gws gmail users messages list --params '{\"userId\": \"me\", \"q\": \"subject:\\\"invoice\\\" in:inbox\"}' --format table`"
+]
+caution = "batchModify accepts up to 1000 ids per request — paginate list and modify for larger result sets. `forward` actions on a filter cannot be replayed against past messages."

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -124,4 +124,5 @@ Multi-step task sequences with real commands.
 | [recipe-batch-invite-to-event](../skills/recipe-batch-invite-to-event/SKILL.md) | Add a list of attendees to an existing Google Calendar event and send notifications. |
 | [recipe-forward-labeled-emails](../skills/recipe-forward-labeled-emails/SKILL.md) | Find Gmail messages with a specific label and forward them to another address. |
 | [recipe-generate-report-from-sheet](../skills/recipe-generate-report-from-sheet/SKILL.md) | Read data from a Google Sheet and create a formatted Google Docs report. |
+| [recipe-apply-filter-to-existing-emails](../skills/recipe-apply-filter-to-existing-emails/SKILL.md) | Apply a Gmail filter's actions to existing messages (API equivalent of the UI 'apply to matching conversations' box). |
 

--- a/skills/recipe-apply-filter-to-existing-emails/SKILL.md
+++ b/skills/recipe-apply-filter-to-existing-emails/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: recipe-apply-filter-to-existing-emails
+description: "Apply a Gmail filter's actions to existing messages (API equivalent of the UI 'apply to matching conversations' box)."
+metadata:
+  version: 0.22.5
+  openclaw:
+    category: "recipe"
+    domain: "productivity"
+    requires:
+      bins:
+        - gws
+      skills:
+        - gws-gmail
+---
+
+# Apply a Gmail Filter to Existing Messages
+
+> **PREREQUISITE:** Load the following skills to execute this recipe: `gws-gmail`
+
+Apply a Gmail filter's actions to existing messages (API equivalent of the UI 'apply to matching conversations' box).
+
+> [!CAUTION]
+> batchModify accepts up to 1000 ids per request — paginate list and modify for larger result sets. `forward` actions on a filter cannot be replayed against past messages.
+
+## Steps
+
+1. Read the filter's criteria and action: `gws gmail users settings filters get --params '{"userId": "me", "id": "FILTER_ID"}'`
+2. List matching messages, translating the criteria to a Gmail query (e.g. `subject:"..."`, `from:...`): `gws gmail users messages list --params '{"userId": "me", "q": "subject:\"invoice\" in:anywhere", "maxResults": 500}'`
+3. Apply the filter's actions in bulk: `gws gmail users messages batchModify --params '{"userId": "me"}' --json '{"ids": ["MSG_ID_1", "MSG_ID_2"], "addLabelIds": ["LABEL_ID"], "removeLabelIds": ["INBOX", "UNREAD"]}'`
+4. Verify the inbox is clear of matches: `gws gmail users messages list --params '{"userId": "me", "q": "subject:\"invoice\" in:inbox"}' --format table`
+


### PR DESCRIPTION
## Description

Adds a new recipe skill, `recipe-apply-filter-to-existing-emails`, that documents how to apply a Gmail filter's actions to **existing** messages — the API equivalent of the Gmail UI's "Also apply filter to matching conversations" checkbox, which has no parameter on `filters.create` and is tracked as feature request [Google Issue Tracker #62715881](https://issuetracker.google.com/62715881).

The recipe walks through:
1. `gws gmail users settings filters get` — read the filter's `criteria` and `action`
2. `gws gmail users messages list` — translate criteria to a Gmail search query
3. `gws gmail users messages batchModify` — apply the filter's label mutations in bulk (up to 1000 ids per request)
4. A verification list call scoped to `in:inbox`

`caution` notes two constraints: the 1000-id batch limit, and that `forward` actions on a filter cannot be replayed against past messages.

The diff is TOML + auto-generated Markdown only — no Rust changes. A `--dry-run` is not applicable (no new CLI surface).

## Development practices followed

- Read `docs/CONTRIBUTING.md` and `AGENTS.md` in full. Confirmed the contribution pattern: recipes are TOML entries in `crates/google-workspace-cli/registry/recipes.toml`; `skills/recipe-*/SKILL.md` and `docs/skills.md` are auto-generated by `gws generate-skills`, not handwritten.
- Added the recipe as a `[[recipes]]` entry with `name`, `title`, `description` (under the 120-char `FRONTMATTER_DESCRIPTION_LIMIT`), `category = "productivity"`, `services = ["gmail"]`, `steps`, and `caution`.
- Regenerated `skills/recipe-apply-filter-to-existing-emails/SKILL.md` and `docs/skills.md` via `cargo run -- generate-skills`. Reverted unrelated drift that the regeneration picked up from upstream Discovery Document updates (Chat `findGroupChats`, Drive `generateCseToken`, Events patch wording, sheets-append `--range` description) — those belong in a separate PR.
- Added `.changeset/recipe-apply-filter-to-existing-emails.md` with `"@googleworkspace/cli": patch`.
- Ran `cargo fmt --all -- --check` (clean) and `cargo test` (701 passed; includes `test_registry_references`, which validates that `services = ["gmail"]` resolves to a valid gws alias).
- Ran `cargo clippy --all-targets -- -D warnings`. It surfaces ~10 pre-existing errors on clean `upstream/main` (`assert_eq!` with bool literal, very-complex-type, etc. in `main.rs`, `commands.rs`, `executor.rs`) that are unrelated to this diff. Likely a clippy-version skew against CI.

## Checklist

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] Ran `cargo fmt --all` — clean.
- [ ] Ran `cargo clippy -- -D warnings` — pre-existing errors on upstream main, none introduced by this diff. Noted above.
- [x] Registry validation test (`test_registry_references`) covers the new entry. No new Rust logic, so no additional tests needed.
- [x] Changeset added (`.changeset/recipe-apply-filter-to-existing-emails.md`, patch).