### PR TITLE
fix(windows): force UTF-8 console output at startup

### DIFF
--- a/.changeset/fix-windows-utf8-console-codepage.md
+++ b/.changeset/fix-windows-utf8-console-codepage.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Force UTF-8 console output on Windows by calling `SetConsoleOutputCP(65001)` at startup, preventing mojibake when the system default codepage is CP-1252

--- a/crates/google-workspace-cli/src/helpers/script.rs
+++ b/crates/google-workspace-cli/src/helpers/script.rs
@@ -169,13 +169,8 @@ fn process_file(path: &Path) -> Result<Option<serde_json::Value>, GwsError> {
             filename.trim_end_matches(".js").trim_end_matches(".gs"),
         ),
         "html" => ("HTML", filename.trim_end_matches(".html")),
-        "json" => {
-            if filename == "appsscript.json" {
-                ("JSON", "appsscript")
-            } else {
-                return Ok(None);
-            }
-        }
+        "json" if filename == "appsscript.json" => ("JSON", "appsscript"),
+        "json" => return Ok(None),
         _ => return Ok(None),
     };
 

--- a/crates/google-workspace-cli/src/main.rs
+++ b/crates/google-workspace-cli/src/main.rs
@@ -47,6 +47,10 @@ use error::{print_error_json, GwsError};
 
 #[tokio::main]
 async fn main() {
+    // Force UTF-8 console output on Windows; no-op on other platforms.
+    #[cfg(windows)]
+    output::set_console_utf8();
+
     // Load .env file if present (silently ignored if missing)
     let _ = dotenvy::dotenv();
 

--- a/crates/google-workspace-cli/src/output.rs
+++ b/crates/google-workspace-cli/src/output.rs
@@ -86,6 +86,27 @@ pub(crate) fn info(msg: &str) {
     eprintln!("{}", sanitize_for_terminal(msg));
 }
 
+// ── Windows console codepage ───────────────────────────────────────────
+
+/// Force the Windows console output codepage to UTF-8 (CP 65001) at startup.
+/// Without this, the default system codepage (typically CP-1252) mangles
+/// non-ASCII characters printed by `println!` before Rust's stdio layer can
+/// re-encode them.
+///
+/// Failure is non-fatal — terminals that already use UTF-8 will behave
+/// correctly regardless, and the call is safe to make unconditionally on any
+/// Windows version that ships `kernel32.dll`.
+#[cfg(windows)]
+pub(crate) fn set_console_utf8() {
+    extern "system" {
+        fn SetConsoleOutputCP(wCodePageID: u32) -> i32;
+    }
+    // SAFETY: SetConsoleOutputCP is a documented Win32 API with no memory-
+    // safety requirements. The return value is ignored because failure is
+    // non-fatal — the terminal simply retains its existing codepage.
+    let _ = unsafe { SetConsoleOutputCP(65001) };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -152,5 +173,24 @@ mod tests {
     fn colorize_returns_text_in_no_color_mode() {
         let result = colorize("hello", "31");
         assert!(result.contains("hello"));
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use super::*;
+
+    #[test]
+    fn set_console_utf8_sets_codepage_65001() {
+        extern "system" {
+            fn GetConsoleOutputCP() -> u32;
+        }
+        set_console_utf8();
+        // GetConsoleOutputCP returns 0 when no console is attached (e.g. in
+        // redirected test output). Only assert when we actually have a console.
+        let cp = unsafe { GetConsoleOutputCP() };
+        if cp != 0 {
+            assert_eq!(cp, 65001, "expected UTF-8 codepage (65001), got {cp}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #742.

On Windows, `gws` inherits the system console codepage (typically CP-1252 or CP-437). When Rust's `println!` writes UTF-8 bytes, the console interprets them using the active codepage, producing mojibake for any non-ASCII characters in API responses (e.g. smart quotes, accented names, emoji).

**Fix:** Call `SetConsoleOutputCP(65001)` via a thin inline FFI shim at the very start of `main()`, before any output is produced. This tells the Windows Console to interpret subsequent output as UTF-8. The call is gated behind `#[cfg(windows)]` so non-Windows builds are unaffected.

No new dependency is added — the function is part of `kernel32.dll` and is called directly via an `extern "system"` block.

### Files changed

| File | Change |
|---|---|
| `crates/google-workspace-cli/src/output.rs` | Add `set_console_utf8()` + Windows-conditional test |
| `crates/google-workspace-cli/src/main.rs` | Call `set_console_utf8()` at startup |
| `crates/google-workspace-cli/src/helpers/script.rs` | Collapse nested `if`-in-`match` to satisfy `clippy::collapsible_match` on latest stable (lint trigger on Rust 1.87+; required for `cargo clippy -- -D warnings` to pass locally) |
| `.changeset/fix-windows-utf8-console-codepage.md` | Patch changeset |

The `script.rs` change is a ride-along lint fix — happy to split it into a separate PR if preferred.

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (702 tests pass; 2 pre-existing Windows-only failures in `auth::tests::test_get_quota_project_*` — those tests set `HOME` but `dirs::home_dir()` on Windows uses `USERPROFILE`, unrelated to this PR)
- [x] `set_console_utf8_sets_codepage_65001` test: calls `SetConsoleOutputCP(65001)` and then `GetConsoleOutputCP()` — confirmed returns `65001` on Windows (skips assertion gracefully when no console is attached, e.g. in CI)
- [x] Binary built and smoke-tested on Windows 11 x86_64

🤖 Generated with [Claude Code](https://claude.com/claude-code)