### PR TITLE
fix(auth): validate --services names and remove automatic cloud-platform injection

### DIFF
--- a/.changeset/fix-741-auth-services-validation.md
+++ b/.changeset/fix-741-auth-services-validation.md
@@ -1,0 +1,7 @@
+---
+"@googleworkspace/cli": patch
+---
+
+`auth login -s` / `--services`: reject unknown service names at parse time with a clear error listing valid names. Previously, unrecognised tokens were silently dropped, causing a token to cover fewer services than the user intended.
+
+**Behavior change:** `cloud-platform` is no longer injected automatically when a `--services` filter is active. It was previously added to every filtered login regardless of the services requested. It still appears when using `--full` (no filter) or the interactive discovery picker (no filter).

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -448,7 +448,7 @@ pub async fn handle_auth_command(args: &[String]) -> Result<(), GwsError> {
 
     match matches.subcommand() {
         Some(("login", sub_m)) => {
-            let (scope_mode, services_filter) = parse_login_args(sub_m);
+            let (scope_mode, services_filter) = parse_login_args(sub_m)?;
 
             handle_login_inner(scope_mode, services_filter).await
         }
@@ -483,7 +483,11 @@ fn login_command() -> clap::Command {
 }
 
 /// Extract `ScopeMode` and optional services filter from parsed login args.
-fn parse_login_args(matches: &clap::ArgMatches) -> (ScopeMode, Option<HashSet<String>>) {
+///
+/// Returns `Err` if any token in `--services` is not a known service alias.
+fn parse_login_args(
+    matches: &clap::ArgMatches,
+) -> Result<(ScopeMode, Option<HashSet<String>>), GwsError> {
     let scope_mode = if let Some(scopes_str) = matches.get_one::<String>("scopes") {
         ScopeMode::Custom(
             scopes_str
@@ -501,14 +505,42 @@ fn parse_login_args(matches: &clap::ArgMatches) -> (ScopeMode, Option<HashSet<St
         ScopeMode::Default
     };
 
-    let services_filter: Option<HashSet<String>> = matches.get_one::<String>("services").map(|v| {
-        v.split(',')
-            .map(|s| s.trim().to_lowercase())
-            .filter(|s| !s.is_empty())
-            .collect()
-    });
+    let services_filter: Option<HashSet<String>> =
+        if let Some(v) = matches.get_one::<String>("services") {
+            let tokens: Vec<String> = v
+                .split(',')
+                .map(|s| s.trim().to_lowercase())
+                .filter(|s| !s.is_empty())
+                .collect();
 
-    (scope_mode, services_filter)
+            let unknown: Vec<&str> = tokens
+                .iter()
+                .filter(|name| {
+                    !crate::services::SERVICES
+                        .iter()
+                        .any(|e| e.aliases.contains(&name.as_str()))
+                })
+                .map(|s| s.as_str())
+                .collect();
+
+            if !unknown.is_empty() {
+                let valid: Vec<&str> = crate::services::SERVICES
+                    .iter()
+                    .flat_map(|e| e.aliases.iter().copied())
+                    .collect();
+                return Err(GwsError::Validation(format!(
+                    "Unknown service(s): {}. Valid services: {}.",
+                    unknown.join(", "),
+                    valid.join(", ")
+                )));
+            }
+
+            Some(tokens.into_iter().collect())
+        } else {
+            None
+        };
+
+    Ok((scope_mode, services_filter))
 }
 
 /// Run the `auth login` flow.
@@ -532,7 +564,7 @@ pub async fn run_login(args: &[String]) -> Result<(), GwsError> {
         Err(e) => return Err(GwsError::Validation(e.to_string())),
     };
 
-    let (scope_mode, services_filter) = parse_login_args(&matches);
+    let (scope_mode, services_filter) = parse_login_args(&matches)?;
 
     handle_login_inner(scope_mode, services_filter).await
 }
@@ -817,11 +849,6 @@ fn scope_matches_service(scope_url: &str, services: &HashSet<String>) -> bool {
         .strip_prefix("https://www.googleapis.com/auth/")
         .unwrap_or(scope_url);
 
-    // cloud-platform is a cross-service scope, always include
-    if short == "cloud-platform" {
-        return true;
-    }
-
     let prefix = short.split('.').next().unwrap_or(short);
 
     services.iter().any(|svc| {
@@ -1102,8 +1129,9 @@ fn run_discovery_scope_picker(
                 }
             }
 
-            // Always include cloud-platform scope
-            if !selected.contains(&PLATFORM_SCOPE.to_string()) {
+            // Include cloud-platform when no services filter is active. When the
+            // user passes -s, they get exactly the services they asked for.
+            if services_filter.is_none() && !selected.contains(&PLATFORM_SCOPE.to_string()) {
                 selected.push(PLATFORM_SCOPE.to_string());
             }
 
@@ -2184,9 +2212,9 @@ mod tests {
     }
 
     #[test]
-    fn scope_matches_service_cloud_platform_always_matches() {
+    fn scope_matches_service_cloud_platform_does_not_match_unrelated_service() {
         let services: HashSet<String> = ["drive"].iter().map(|s| s.to_string()).collect();
-        assert!(scope_matches_service(
+        assert!(!scope_matches_service(
             "https://www.googleapis.com/auth/cloud-platform",
             &services
         ));
@@ -2248,9 +2276,7 @@ mod tests {
                 .strip_prefix("https://www.googleapis.com/auth/")
                 .unwrap_or(scope);
             assert!(
-                short.starts_with("drive")
-                    || short.starts_with("gmail")
-                    || short == "cloud-platform",
+                short.starts_with("drive") || short.starts_with("gmail"),
                 "Unexpected scope with service filter: {scope}"
             );
         }
@@ -2274,7 +2300,7 @@ mod tests {
                 .strip_prefix("https://www.googleapis.com/auth/")
                 .unwrap_or(scope);
             assert!(
-                short.starts_with("drive") || short == "cloud-platform",
+                short.starts_with("drive"),
                 "Unexpected scope with service + readonly filter: {scope}"
             );
         }
@@ -2289,7 +2315,7 @@ mod tests {
                 .strip_prefix("https://www.googleapis.com/auth/")
                 .unwrap_or(scope);
             assert!(
-                short.starts_with("gmail") || short == "cloud-platform",
+                short.starts_with("gmail"),
                 "Unexpected scope with service + full filter: {scope}"
             );
         }
@@ -2305,6 +2331,31 @@ mod tests {
         );
         assert_eq!(scopes.len(), 1);
         assert_eq!(scopes[0], "https://www.googleapis.com/auth/calendar");
+    }
+
+    #[test]
+    fn parse_login_args_rejects_unknown_service() {
+        let cmd = login_command();
+        let matches = cmd
+            .try_get_matches_from(["login", "--services", "drive,typoservice"])
+            .unwrap();
+        let result = parse_login_args(&matches);
+        assert!(result.is_err());
+        let msg = result.err().expect("expected error").to_string();
+        assert!(msg.contains("typoservice"), "error should name the unknown token: {msg}");
+        assert!(msg.contains("drive"), "error should list valid services: {msg}");
+    }
+
+    #[test]
+    fn parse_login_args_accepts_known_services() {
+        let cmd = login_command();
+        let matches = cmd
+            .try_get_matches_from(["login", "--services", "Drive,Gmail"])
+            .unwrap();
+        let (_, filter) = parse_login_args(&matches).unwrap();
+        let services = filter.unwrap();
+        assert!(services.contains("drive"), "should lowercase: {services:?}");
+        assert!(services.contains("gmail"), "should lowercase: {services:?}");
     }
 
     #[test]

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -513,24 +513,36 @@ fn parse_login_args(
                 .filter(|s| !s.is_empty())
                 .collect();
 
+            // Platform scopes recognised by the tool but not registered as
+            // Workspace API services (they lack an API discovery entry).
+            const PLATFORM_SCOPES: &[&str] = &["cloud-platform", "pubsub"];
+
             let unknown: Vec<&str> = tokens
                 .iter()
                 .filter(|name| {
-                    !crate::services::SERVICES
-                        .iter()
-                        .any(|e| e.aliases.contains(&name.as_str()))
+                    let n = name.as_str();
+                    !PLATFORM_SCOPES.contains(&n)
+                        && !crate::services::SERVICES
+                            .iter()
+                            .any(|e| e.aliases.contains(&n))
                 })
                 .map(|s| s.as_str())
                 .collect();
 
             if !unknown.is_empty() {
-                let valid: Vec<&str> = crate::services::SERVICES
+                let mut valid: Vec<&str> = crate::services::SERVICES
                     .iter()
                     .flat_map(|e| e.aliases.iter().copied())
                     .collect();
+                valid.extend(PLATFORM_SCOPES);
+                valid.sort_unstable();
                 return Err(GwsError::Validation(format!(
                     "Unknown service(s): {}. Valid services: {}.",
-                    unknown.join(", "),
+                    unknown
+                        .iter()
+                        .map(|s| s.escape_debug().to_string())
+                        .collect::<Vec<_>>()
+                        .join(", "),
                     valid.join(", ")
                 )));
             }
@@ -2356,6 +2368,24 @@ mod tests {
         let services = filter.unwrap();
         assert!(services.contains("drive"), "should lowercase: {services:?}");
         assert!(services.contains("gmail"), "should lowercase: {services:?}");
+    }
+
+    #[test]
+    fn parse_login_args_accepts_platform_scopes() {
+        let cmd = login_command();
+        let matches = cmd
+            .try_get_matches_from(["login", "--services", "cloud-platform,pubsub"])
+            .unwrap();
+        let (_, filter) = parse_login_args(&matches).unwrap();
+        let services = filter.unwrap();
+        assert!(
+            services.contains("cloud-platform"),
+            "cloud-platform should be accepted: {services:?}"
+        );
+        assert!(
+            services.contains("pubsub"),
+            "pubsub should be accepted: {services:?}"
+        );
     }
 
     #[test]

--- a/crates/google-workspace-cli/src/helpers/script.rs
+++ b/crates/google-workspace-cli/src/helpers/script.rs
@@ -169,13 +169,7 @@ fn process_file(path: &Path) -> Result<Option<serde_json::Value>, GwsError> {
             filename.trim_end_matches(".js").trim_end_matches(".gs"),
         ),
         "html" => ("HTML", filename.trim_end_matches(".html")),
-        "json" => {
-            if filename == "appsscript.json" {
-                ("JSON", "appsscript")
-            } else {
-                return Ok(None);
-            }
-        }
+        "json" if filename == "appsscript.json" => ("JSON", "appsscript"),
         _ => return Ok(None),
     };
 


### PR DESCRIPTION
## Summary

Fixes two related bugs in `gws auth login -s` / `--services` reported in #741:

- **Unknown service names were silently dropped.** `parse_login_args()` now validates every token in the `-s` list against the built-in service registry (`crate::services::SERVICES`) before opening the browser. If any token is unrecognised, the command exits non-zero with a clear error that names the bad token(s) and lists all valid service names. Tokens are lowercased before checking, so `-s Drive` and `-s drive` both work.

- **`cloud-platform` was unconditionally injected when a services filter was active.** `scope_matches_service()` previously returned `true` for `cloud-platform` regardless of what services the user asked for, so `-s drive` silently included `cloud-platform` in the resulting token. The unconditional pass-through is removed; `cloud-platform` is now filtered the same way as any other scope. `run_discovery_scope_picker()` retains the auto-add behaviour when *no* services filter is active (the existing unfiltered-interactive flow is unchanged).

**Behaviour change note:** Users who relied on `-s <anything>` always producing a token that includes `cloud-platform` will need to add `cloud-platform` explicitly via `--scopes` or omit the `-s` filter. This is an intentional correction: the previous injection violated the principle of least privilege and contradicted explicitly declined scopes.

Also fixes a pre-existing `clippy::collapsible_match` in `helpers/script.rs` (same lint fixed in #744, which targets the same upstream/main base).

## Test plan

- [x] `parse_login_args_rejects_unknown_service` — error returned for typo token, message names the bad token and lists valid services
- [x] `parse_login_args_accepts_known_services` — `Drive,Gmail` accepted and lowercased correctly
- [x] `scope_matches_service_cloud_platform_does_not_match_unrelated_service` — cloud-platform no longer auto-passes the drive filter
- [x] `resolve_scopes_with_services_filter` — filtered result contains only drive/gmail scopes, no cloud-platform
- [x] `resolve_scopes_services_takes_priority_with_readonly` — readonly + drive filter: only drive scopes
- [x] `resolve_scopes_services_takes_priority_with_full` — full + gmail filter: only gmail scopes
- [x] Full test suite: `cargo test -p google-workspace-cli` — 701 passed, 2 pre-existing failures (unrelated to this change), 0 new failures
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)