### PR TITLE
fix(drive): pass supportsAllDrives=true in +upload to support Shared Drives

### DIFF
--- a/.changeset/fix-722-drive-upload-shared-drives.md
+++ b/.changeset/fix-722-drive-upload-shared-drives.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+`drive +upload`: pass `supportsAllDrives=true` on every upload request so files can be placed inside Shared Drive folders via `--parent`. Previously, any `--parent` pointing to a Shared Drive folder was rejected by the API with a 404 or permission error even when the user had access.

--- a/crates/google-workspace-cli/src/helpers/drive.rs
+++ b/crates/google-workspace-cli/src/helpers/drive.rs
@@ -56,11 +56,13 @@ impl Helper for DriveHelper {
 EXAMPLES:
   gws drive +upload ./report.pdf
   gws drive +upload ./report.pdf --parent FOLDER_ID
+  gws drive +upload ./report.pdf --parent SHARED_DRIVE_FOLDER_ID
   gws drive +upload ./data.csv --name 'Sales Data.csv'
 
 TIPS:
   MIME type is detected automatically.
-  Filename is inferred from the local path unless --name is given.",
+  Filename is inferred from the local path unless --name is given.
+  Shared Drive folders are supported: pass the folder ID via --parent.",
                 ),
         );
         cmd
@@ -105,7 +107,7 @@ TIPS:
                 executor::execute_method(
                     doc,
                     create_method,
-                    None,
+                    Some(r#"{"supportsAllDrives": true}"#),
                     Some(&body_str),
                     token.as_deref(),
                     auth_method,


### PR DESCRIPTION
## Problem

`drive +upload` calls `files.create` without the `supportsAllDrives=true` query parameter. The Drive API rejects any request that targets a Shared Drive folder (via `--parent`) unless this parameter is present, returning a 404 or 403 even when the user has full access to the Shared Drive.

Reported in #722.

## Fix

Pass `supportsAllDrives: true` unconditionally in the query params for every `+upload` call. This parameter is documented as harmless for My Drive uploads — it simply opts the request into Shared Drive awareness.

```
$ gws drive +upload ./file.txt --parent SHARED_DRIVE_FOLDER_ID --dry-run
{
  "query_params": [["supportsAllDrives", "true"]],
  ...
}
```

Updated `after_help` text to document Shared Drive support.

## Test plan

- [x] Dry-run output confirms `supportsAllDrives=true` appears in `query_params`
- [x] All 5 existing `helpers::drive` unit tests pass
- [x] My Drive uploads unaffected (parameter is a no-op when not targeting a Shared Drive)

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)