### PR TITLE
fix(gmail): rename +read --format to --body-format to avoid global flag collision

### DIFF
--- a/.changeset/fix-read-format-collision.md
+++ b/.changeset/fix-read-format-collision.md
@@ -1,0 +1,19 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Fix `+read` local `--format` arg colliding with the global `--format` flag.
+
+Previously, `gmail +read` defined a local `--format` arg (values: `text`, `json`,
+default: `text`). Because the global `--format` flag is declared with
+`.global(true)`, clap propagated the `text` default up to the parent matches,
+causing `main.rs` to emit a spurious `"unknown output format 'text'; falling back
+to json"` warning on every `+read` invocation.
+
+The local arg is renamed to `--body-format` to eliminate the name collision.
+`--body-format text` (default) renders the decoded message body as plain text;
+`--body-format json` returns the full structured JSON object, matching the previous
+`--format json` behaviour.
+
+**Migration note:** Scripts or aliases using `gws gmail +read --format json` must
+be updated to `gws gmail +read --body-format json`.

--- a/crates/google-workspace-cli/src/helpers/gmail/mod.rs
+++ b/crates/google-workspace-cli/src/helpers/gmail/mod.rs
@@ -1808,9 +1808,9 @@ Use fragment tags (<p>, <b>, <a>, etc.) — no <html>/<body> wrapper needed.
                         .action(ArgAction::SetTrue),
                 )
                 .arg(
-                    Arg::new("format")
-                        .long("format")
-                        .help("Output format (text, json)")
+                    Arg::new("body-format")
+                        .long("body-format")
+                        .help("Body rendering format: text (default) or json")
                         .value_parser(["text", "json"])
                         .default_value("text"),
                 )
@@ -1831,7 +1831,7 @@ Use fragment tags (<p>, <b>, <a>, etc.) — no <html>/<body> wrapper needed.
 EXAMPLES:
   gws gmail +read --id 18f1a2b3c4d
   gws gmail +read --id 18f1a2b3c4d --headers
-  gws gmail +read --id 18f1a2b3c4d --format json | jq '.body'
+  gws gmail +read --id 18f1a2b3c4d --body-format json | jq '.body_text'
 
 TIPS:
   Converts HTML-only messages to plain text automatically.

--- a/crates/google-workspace-cli/src/helpers/gmail/read.rs
+++ b/crates/google-workspace-cli/src/helpers/gmail/read.rs
@@ -35,7 +35,7 @@ pub(super) async fn handle_read(
         fetch_message_metadata(&client, &t, message_id).await?
     };
 
-    let format = matches.get_one::<String>("format").unwrap();
+    let format = matches.get_one::<String>("body-format").unwrap();
     let show_headers = matches.get_flag("headers");
     let use_html = matches.get_flag("html");
 

--- a/crates/google-workspace-cli/src/helpers/script.rs
+++ b/crates/google-workspace-cli/src/helpers/script.rs
@@ -169,13 +169,8 @@ fn process_file(path: &Path) -> Result<Option<serde_json::Value>, GwsError> {
             filename.trim_end_matches(".js").trim_end_matches(".gs"),
         ),
         "html" => ("HTML", filename.trim_end_matches(".html")),
-        "json" => {
-            if filename == "appsscript.json" {
-                ("JSON", "appsscript")
-            } else {
-                return Ok(None);
-            }
-        }
+        "json" if filename == "appsscript.json" => ("JSON", "appsscript"),
+        "json" => return Ok(None),
         _ => return Ok(None),
     };
 


### PR DESCRIPTION
## Problem

Closes #740 (partial — format-collision sub-issue)

`gmail +read` defined a local `--format` arg with `default_value("text")` and
`value_parser(["text", "json"])`. The root `--format` flag is declared
`.global(true)`, so clap propagated the `"text"` default up to the root
`ArgMatches`. `main.rs` reads the global `--format` value, gets `"text"`,
doesn't recognise it as a valid output format (valid: `json`, `table`, `yaml`,
`csv`), and emits a spurious warning on every `+read` invocation:

```
warning: unknown output format 'text'; falling back to json (valid options: json, table, yaml, csv)
```

## Fix

Rename the `+read` local arg from `--format` to `--body-format`. The name
collision is eliminated; the global `--format` flag is now unambiguous when
`+read` is the active subcommand.

Behaviour is otherwise unchanged:

| Flag | Effect |
|---|---|
| *(omit)* | Render decoded message body as plain text (default) |
| `--body-format text` | Same as above |
| `--body-format json` | Return the full structured JSON object |

The `after_help` example is updated from `--format json` to `--body-format json`.

## Migration note

Scripts or aliases using `gws gmail +read --format json` must be updated to
`gws gmail +read --body-format json`.

## Testing

- `cargo clippy -- -D warnings`: clean
- `cargo test`: 699 pass, 2 fail (pre-existing `test_get_quota_project_*` ADC
  environment tests unrelated to this change — confirmed failing on unmodified
  `upstream/main` too)

Also collapses a pre-existing `clippy::collapsible_match` in `helpers/script.rs`
that surfaces on every fresh branch from `upstream/main` (same fix as PRs #744,
#747, #748, #749, #750).

🤖 Generated with [Claude Code](https://claude.com/claude-code)