### PR TITLE
fix(executor): warn to stderr when 2xx response has empty body

### DIFF
--- a/.changeset/empty-body-diagnostic.md
+++ b/.changeset/empty-body-diagnostic.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Warn to stderr when an API call succeeds but returns an empty response body

--- a/crates/google-workspace-cli/src/executor.rs
+++ b/crates/google-workspace-cli/src/executor.rs
@@ -495,6 +495,15 @@ pub async fn execute_method(
                 .await
                 .context("Failed to read response body")?;
 
+            if body_text.is_empty() {
+                eprintln!(
+                    "Warning: {} returned HTTP {} with an empty response body.",
+                    method_id,
+                    status.as_u16()
+                );
+                break;
+            }
+
             let should_continue = handle_json_response(
                 &body_text,
                 pagination,
@@ -2023,6 +2032,63 @@ mod tests {
             }
             _ => panic!("Expected Api error"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_handle_json_response_empty_body_returns_no_continue() {
+        let pagination = PaginationConfig::default();
+        let output_format = crate::formatter::OutputFormat::Json;
+        let sanitize_mode = crate::helpers::modelarmor::SanitizeMode::Warn;
+        let mut pages_fetched = 0u32;
+        let mut page_token: Option<String> = None;
+        let mut captured: Vec<Value> = Vec::new();
+
+        let result = handle_json_response(
+            "",
+            &pagination,
+            None,
+            &sanitize_mode,
+            &output_format,
+            &mut pages_fetched,
+            &mut page_token,
+            false,
+            &mut captured,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(!result.unwrap(), "empty body: should not continue pagination");
+        assert_eq!(pages_fetched, 0, "empty body: pages_fetched should not increment");
+        assert!(captured.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_handle_json_response_valid_json_increments_pages() {
+        let pagination = PaginationConfig::default();
+        let output_format = crate::formatter::OutputFormat::Json;
+        let sanitize_mode = crate::helpers::modelarmor::SanitizeMode::Warn;
+        let mut pages_fetched = 0u32;
+        let mut page_token: Option<String> = None;
+        let mut captured: Vec<Value> = Vec::new();
+
+        let result = handle_json_response(
+            r#"{"id": "abc"}"#,
+            &pagination,
+            None,
+            &sanitize_mode,
+            &output_format,
+            &mut pages_fetched,
+            &mut page_token,
+            true,
+            &mut captured,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(!result.unwrap(), "single page: should not continue pagination");
+        assert_eq!(pages_fetched, 1);
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0]["id"], "abc");
     }
 }
 

--- a/crates/google-workspace-cli/src/helpers/script.rs
+++ b/crates/google-workspace-cli/src/helpers/script.rs
@@ -169,13 +169,7 @@ fn process_file(path: &Path) -> Result<Option<serde_json::Value>, GwsError> {
             filename.trim_end_matches(".js").trim_end_matches(".gs"),
         ),
         "html" => ("HTML", filename.trim_end_matches(".html")),
-        "json" => {
-            if filename == "appsscript.json" {
-                ("JSON", "appsscript")
-            } else {
-                return Ok(None);
-            }
-        }
+        "json" if filename == "appsscript.json" => ("JSON", "appsscript"),
         _ => return Ok(None),
     };
 


### PR DESCRIPTION
## Problem

When an API call succeeds (2xx HTTP status) but returns an empty response
body, `execute_method()` silently discards the response: no output, no
warning, exit 0. Users see nothing and have no indication of what happened.

This is tracked in #740 (sub-issue: empty-body diagnostic). The companion
fix for the `+read --format` global flag collision was submitted in #751.

## Root cause

In `execute_method()`, after reading `body_text`, `handle_json_response()`
is called unconditionally. When `body_text` is empty, `serde_json::from_str`
fails, the else branch runs, and the condition
`!capture_output && !body_text.is_empty()` is false — nothing is printed,
no error is returned, and the function exits with `Ok(None)`.

## Fix

Add a guard in `execute_method()` between reading `body_text` and calling
`handle_json_response()`: if `body_text` is empty on a 2xx response, print
a `Warning:` message to stderr (including the method ID and HTTP status) and
break out of the pagination loop.

The exit code remains 0 because the HTTP call itself succeeded. A non-zero
exit was considered, but `GwsError::Other` would also write
`{"error": {"code": 500, "reason": "internalError"}}` to stdout, which is
misleading for a 200 OK response and breaks the stdout=data contract.
Scripts needing automated detection of empty-body responses should check
stderr for the `Warning:` prefix.

```
$ gws drive files.get fileId=abc123
Warning: drive.files.get returned HTTP 200 with an empty response body.
```

## Tests

Two new unit tests for `handle_json_response()`:
- `test_handle_json_response_empty_body_returns_no_continue` — verifies
  empty body returns `Ok(false)` without panicking and does not increment
  `pages_fetched`. This covers the underlying function behavior (the new
  guard in `execute_method()` prevents it from being called with an empty
  body in practice, but the function handles it gracefully as a fallback).
- `test_handle_json_response_valid_json_increments_pages` — regression test
  for the normal JSON path.

Testing the `execute_method()` guard end-to-end would require a mock HTTP
server; there is no such infrastructure in this crate currently.

## Other changes

Collapses a pre-existing `clippy::collapsible_match` in
`helpers/script.rs` (same warning present on `upstream/main`).