### PR TITLE
fix(auth): map meet service to meetings scope prefix

### DIFF
--- a/.changeset/auth-meet-scopes.md
+++ b/.changeset/auth-meet-scopes.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Fix `gws auth login -s meet` not granting any Meet scopes. The Meet API exposes scopes under the `meetings.*` prefix (e.g. `meetings.space.readonly`), but the CLI's service alias is `meet`, so the scope-picker filter matched nothing and silently dropped every Meet scope. Map the `meet` service to the `meetings` scope prefix so the existing dynamic-augmentation path pulls all Meet scopes from the Discovery document when `-s meet` is supplied.

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -841,6 +841,7 @@ fn map_service_to_scope_prefixes(service: &str) -> Vec<&str> {
         "slides" => vec!["presentations"],
         "docs" => vec!["documents"],
         "people" => vec!["contacts", "directory"],
+        "meet" => vec!["meetings"],
         s => vec![s],
     }
 }
@@ -2232,6 +2233,23 @@ mod tests {
         ));
         assert!(scope_matches_service(
             "https://www.googleapis.com/auth/chat.messages",
+            &services
+        ));
+    }
+
+    #[test]
+    fn scope_matches_service_meet() {
+        let services: HashSet<String> = ["meet"].iter().map(|s| s.to_string()).collect();
+        assert!(scope_matches_service(
+            "https://www.googleapis.com/auth/meetings.space.created",
+            &services
+        ));
+        assert!(scope_matches_service(
+            "https://www.googleapis.com/auth/meetings.space.readonly",
+            &services
+        ));
+        assert!(scope_matches_service(
+            "https://www.googleapis.com/auth/meetings.space.settings",
             &services
         ));
     }


### PR DESCRIPTION
> Reopening #736, which was auto-closed by the stale-bot after 72h of inactivity despite an approving automated review and no outstanding maintainer feedback. Identical commit (`28366ec`); nothing has changed. Happy to rebase or address any review feedback.

## Description

`gws auth login -s meet` (and multi-service filters like `-s drive,gmail,calendar,sheets,docs,meet,tasks`) silently requests zero Meet scopes, so subsequent calls like `gws meet conferenceRecords list` fail with `403 insufficient authentication scopes`.

The cause is a naming mismatch: the CLI service alias is `meet`, but Google's Meet API scopes are `https://www.googleapis.com/auth/meetings.*`. `map_service_to_scope_prefixes` returned `"meet"` via its catch-all arm, so `scope_matches_service` filtered every Meet scope out of both the picker and `find_unmatched_services`.

The fix is a one-liner in the same spot that already special-cases `sheets`, `slides`, `docs`, and `people`:

```rust
"meet" => vec!["meetings"],
```

Once the filter correctly classifies `meet` as unmatched, the existing `augment_with_dynamic_scopes` path picks up all three Meet scopes from the Discovery document on its own. No changes to `FULL_SCOPES` or `SCOPE_ENTRIES` — those intentionally list only the core Workspace services, not every supported API.

Closes #556. Continuation of #565 and #736, both auto-closed by the stale-bot. Credit to @anshul-garg27 for the original diagnosis; this PR is narrower (just the mapping change) and aligned with the convention set by #414.

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings. (13 pre-existing errors in `main.rs` reproduce on clean `main` — out of scope.)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.
