### PR TITLE
fix: correct gws docs +write flags in recipe-post-mortem-setup

### DIFF
--- a/.changeset/fix-post-mortem-docs-write.md
+++ b/.changeset/fix-post-mortem-docs-write.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Fix recipe-post-mortem-setup to use correct gws docs +write flags (--document and --text instead of --title and --body)

--- a/skills/recipe-post-mortem-setup/SKILL.md
+++ b/skills/recipe-post-mortem-setup/SKILL.md
@@ -23,7 +23,8 @@ Create a Google Docs post-mortem, schedule a Google Calendar review, and notify 
 
 ## Steps
 
-1. Create post-mortem doc: `gws docs +write --title 'Post-Mortem: [Incident]' --body '## Summary\n\n## Timeline\n\n## Root Cause\n\n## Action Items'`
-2. Schedule review meeting: `gws calendar +insert --summary 'Post-Mortem Review: [Incident]' --attendee team@company.com --start '2026-03-16T14:00:00' --end '2026-03-16T15:00:00'`
-3. Notify in Chat: `gws chat +send --space spaces/ENG_SPACE --text '🔍 Post-mortem scheduled for [Incident].'`
+1. Create post-mortem doc: `gws docs documents create --json '{"title": "Post-Mortem: [Incident]"}'` (note the returned `documentId`)
+2. Write post-mortem template: `gws docs +write --document <documentId> --text '## Summary\n\n## Timeline\n\n## Root Cause\n\n## Action Items'`
+3. Schedule review meeting: `gws calendar +insert --summary 'Post-Mortem Review: [Incident]' --attendee team@company.com --start '2026-03-16T14:00:00' --end '2026-03-16T15:00:00'`
+4. Notify in Chat: `gws chat +send --space spaces/ENG_SPACE --text '🔍 Post-mortem scheduled for [Incident].'`
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

The `recipe-post-mortem-setup` skill contains an invalid `gws docs +write` invocation. The flags `--title` and `--body` do not exist on the `+write` subcommand. The correct flags are `--document <ID>` and `--text <TEXT>`. Additionally, the document must be created first (via `gws docs documents create`) to obtain a `documentId` before any content can be written to it. Without this fix, the recipe fails at step 1 with an unrecognized flag error, making the entire post-mortem workflow non-functional.

The fix splits the original step 1 into two steps: first create the document and capture the returned `documentId`, then write the template content using the correct flags.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-broken-reference","fingerprint":"sha256:7a2087bd83faf7caf5c8954c5d0055864b2f2c656c5ee608f120b2695e87a6ff"}]}
nlpm-metadata-end -->