### PR TITLE
fix: replace nonexistent Forms API list method with Drive files list

### DIFF
--- a/.changeset/fix-collect-form-responses-list.md
+++ b/.changeset/fix-collect-form-responses-list.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Fix recipe-collect-form-responses to use Drive API to list forms (Forms API has no list method)

--- a/skills/recipe-collect-form-responses/SKILL.md
+++ b/skills/recipe-collect-form-responses/SKILL.md
@@ -11,17 +11,18 @@ metadata:
         - gws
       skills:
         - gws-forms
+        - gws-drive
 ---
 
 # Check Form Responses
 
-> **PREREQUISITE:** Load the following skills to execute this recipe: `gws-forms`
+> **PREREQUISITE:** Load the following skills to execute this recipe: `gws-forms`, `gws-drive`
 
 Retrieve and review responses from a Google Form.
 
 ## Steps
 
-1. List forms: `gws forms forms list` (if you don't have the form ID)
+1. Find your form ID: `gws drive files list --params "{\"q\": \"mimeType = 'application/vnd.google-apps.form' and trashed = false\"}" --format table`
 2. Get form details: `gws forms forms get --params '{"formId": "FORM_ID"}'`
 3. Get responses: `gws forms forms responses list --params '{"formId": "FORM_ID"}' --format table`
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

The `recipe-collect-form-responses` skill references `gws forms forms list` in step 1. The Google Forms API v1 does not have a `list` method on the `forms` resource — it only supports `get`, `create`, `patch`, `batchUpdate`, and `responses.list`. Calling this command will always return an API error, making it impossible for users to discover their form IDs through the recipe.

The fix replaces step 1 with a Drive API files list query filtered to `application/vnd.google-apps.form` MIME type, which correctly enumerates all Google Forms in the user's Drive. Since this now depends on the Drive API, `gws-drive` is added as a prerequisite skill in both the YAML frontmatter `skills:` list and the `PREREQUISITE` line in the body.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-broken-reference","fingerprint":"sha256:99765b5c957f40f0ba430c0f67d6df3ab2f4a7012b96f823937471e5d9ea9206"}]}
nlpm-metadata-end -->