### PR TITLE
fix: pin devDependencies to exact versions in package.json

### DIFF
--- a/.changeset/fix-pin-dev-deps.md
+++ b/.changeset/fix-pin-dev-deps.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Pin devDependencies to exact versions to prevent unreviewed minor/patch updates

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "rust"
   ],
   "devDependencies": {
-    "@changesets/cli": "^2.29.8",
-    "lefthook": "^2.1.2"
+    "@changesets/cli": "2.29.8",
+    "lefthook": "2.1.2"
   }
 }


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

`package.json` uses caret ranges (`^`) for both `@changesets/cli` and `lefthook` in `devDependencies`. Caret ranges allow any compatible minor or patch version to be installed without an explicit update commit. This means:

1. A `pnpm install` in a fresh environment (e.g., a new developer machine or a CI ephemeral runner without a cache) can silently pull in a newer version than the one tested.
2. Supply-chain updates — including potentially malicious patch releases — could reach developer environments and CI without a code review.

Pinning to exact versions (`2.29.8` and `2.1.2`) ensures that every dependency upgrade is a deliberate, reviewable change. The existing `pnpm-lock.yaml` already records exact resolved versions; this change makes `package.json` consistent with that intent.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-unpinned-semver","fingerprint":"sha256:cc6dd0163e79cb9765bf8cff593f2d0bf97402bce9faf742ea55e61456870ae2"}]}
nlpm-metadata-end -->