### PR TITLE
fix(auth): route "Using keyring backend" log through tracing

### DIFF
--- a/.changeset/keyring-backend-tracing.md
+++ b/.changeset/keyring-backend-tracing.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Route the "Using keyring backend" log line through `tracing::info!` instead of raw `eprintln!`. The line now respects `GOOGLE_WORKSPACE_CLI_LOG` (so users can suppress it via `gws=warn` as the help text already advertises) and reaches the JSON log pipeline configured by `GOOGLE_WORKSPACE_CLI_LOG_FILE`.

--- a/crates/google-workspace-cli/src/credential_store.rs
+++ b/crates/google-workspace-cli/src/credential_store.rs
@@ -356,8 +356,8 @@ fn get_or_create_key() -> anyhow::Result<[u8; 32]> {
     #[cfg(test)]
     let backend = KeyringBackend::File; // Force file to avoid native keychain prompts during test execution
 
-    // Item 5: log which backend was selected
-    eprintln!("Using keyring backend: {}", backend.as_str());
+    // Item 5: log which backend was selected (audit trail; controlled by GOOGLE_WORKSPACE_CLI_LOG)
+    tracing::info!(backend = backend.as_str(), "Using keyring backend");
 
     let username = std::env::var("USER")
         .or_else(|_| std::env::var("USERNAME"))


### PR DESCRIPTION
## Problem

`credential_store.rs::get_or_create_key` writes the keyring-backend selection
line via raw `eprintln!`, bypassing the `tracing` infrastructure the crate
already builds:

```rust
// crates/google-workspace-cli/src/credential_store.rs:360 (main)
// Item 5: log which backend was selected
eprintln!("Using keyring backend: {}", backend.as_str());
```

Two visible consequences:

1. **The documented `GOOGLE_WORKSPACE_CLI_LOG` env var cannot suppress it.**
   `gws --help` advertises `GOOGLE_WORKSPACE_CLI_LOG  Log level for stderr (e.g., gws=debug)`,
   but `gws=off`, `gws=warn`, and `gws=error` all leave the banner on stderr.
2. **Pipelines that merge stdout + stderr break.** Any consumer that captures
   both streams (`tee 2>&1`, CI log captures, AI-agent tool harnesses that store
   merged output to a file) ends up with a non-JSON line prepended to otherwise
   pure-JSON stdout, breaking downstream parsers like ` | jq` and
   `python3 -c 'json.load(sys.stdin)'`. This was the immediate trigger for the
   PR — an agent harness merged streams into a tool-result file, and the next
   step's `cat … | jq` choked on the leading banner.

## Reproducer

```bash
$ GOOGLE_WORKSPACE_CLI_LOG=gws=off gws calendar events list \
    --params '{"calendarId":"primary","maxResults":1}' 2>&1 1>/dev/null
Using keyring backend: file        # expected: nothing on stderr
```

```bash
$ gws calendar events list --params '{"calendarId":"primary","maxResults":1}' 2>&1 \
    | python3 -c 'import sys,json; json.load(sys.stdin)'
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

## Fix

Replace the `eprintln!` with `tracing::info!` using the structured-fields style
already used in `executor.rs:468-477` (`tracing::warn!` / `tracing::debug!` with
`field = value, "Message"`):

```diff
-    // Item 5: log which backend was selected
-    eprintln!("Using keyring backend: {}", backend.as_str());
+    // Item 5: log which backend was selected (audit trail; controlled by GOOGLE_WORKSPACE_CLI_LOG)
+    tracing::info!(backend = backend.as_str(), "Using keyring backend");
```

## Why this is the right shape

- **Preserves maintainer intent.** The comment ("Item 5: log which backend was
  selected") indicates the line is intentional audit telemetry. Routing it
  through `tracing` keeps it audit-grade and adds it to the JSON log file
  pipeline that `GOOGLE_WORKSPACE_CLI_LOG_FILE` already builds.
- **Backwards compatible.** Default `tracing` subscriber level is `INFO`, so the
  message remains visible by default. Only users who actively opt out
  (`GOOGLE_WORKSPACE_CLI_LOG=gws=warn`) see a behavior change — and that change
  is exactly what `gws --help` already promises.
- **Matches existing crate style.** No new imports (the file is consistent with
  fully-qualified `tracing::*` calls used elsewhere). Structured `backend = ...`
  field is queryable in JSON logs, mirroring `executor.rs`.
- **Minimal diff.** 2 lines changed, no API changes, no test changes needed.

## Verification

- `tracing = "0.1"` is already a workspace dep
  (`crates/google-workspace-cli/Cargo.toml:64`).
- The macro call shape is identical to existing usages in
  `executor.rs:468-477`. CI (`.github/workflows/ci.yml`) will compile-check the
  Rust paths filter on this PR.
- No new imports required; `tracing` is invoked fully-qualified, matching the
  file's existing convention.

Happy to amend with additional tests or a release-notes entry if useful.

Made with [Cursor](https://cursor.com)