### PR TITLE
fix(script): skip ignored directories during push

### DIFF
--- a/.changeset/script-skip-ignored-dirs.md
+++ b/.changeset/script-skip-ignored-dirs.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Skip ignored directories while collecting files for `gws script +push`.

--- a/crates/google-workspace-cli/src/helpers/script.rs
+++ b/crates/google-workspace-cli/src/helpers/script.rs
@@ -145,6 +145,10 @@ fn visit_dirs(dir: &Path, files: &mut Vec<serde_json::Value>) -> Result<(), GwsE
             let entry = entry.context("Failed to read entry")?;
             let path = entry.path();
             if path.is_dir() {
+                let dirname = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+                if dirname.starts_with('.') || dirname == "node_modules" {
+                    continue;
+                }
                 visit_dirs(&path, files)?;
             } else if let Some(file_obj) = process_file(&path)? {
                 files.push(file_obj);
@@ -169,13 +173,8 @@ fn process_file(path: &Path) -> Result<Option<serde_json::Value>, GwsError> {
             filename.trim_end_matches(".js").trim_end_matches(".gs"),
         ),
         "html" => ("HTML", filename.trim_end_matches(".html")),
-        "json" => {
-            if filename == "appsscript.json" {
-                ("JSON", "appsscript")
-            } else {
-                return Ok(None);
-            }
-        }
+        "json" if filename == "appsscript.json" => ("JSON", "appsscript"),
+        "json" => return Ok(None),
         _ => return Ok(None),
     };
 
@@ -276,6 +275,14 @@ mod tests {
         // Ignored file
         let f3 = dir.path().join("ignore.txt");
         File::create(&f3).unwrap();
+
+        let hidden = dir.path().join(".hidden");
+        fs::create_dir(&hidden).unwrap();
+        File::create(hidden.join("secret.gs")).unwrap();
+
+        let node_modules = dir.path().join("node_modules");
+        fs::create_dir(&node_modules).unwrap();
+        File::create(node_modules.join("dep.gs")).unwrap();
 
         let mut files = Vec::new();
         visit_dirs(dir.path(), &mut files).unwrap();


### PR DESCRIPTION
## Description

`gws script +push` should ignore directories like hidden folders and `node_modules` while collecting Apps Script files. Previously, the helper still descended into those directories and only filtered some files after traversal.

This PR skips ignored directories before recursion, so `+push` avoids unnecessary traversal and does not collect files from hidden directories. It also includes a small clippy cleanup in the same file so the repo's pre-submit command passes locally.

**Dry Run Output:**
```json
// Not applicable: this changes local file collection before request creation.
```

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.

## Testing

- `cargo test -q`
- `cargo clippy -- -D warnings`
