### PR TITLE
fix(sheets): require values for append helper

### DIFF
--- a/.changeset/sheets-append-require-values.md
+++ b/.changeset/sheets-append-require-values.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Require row data when using `gws sheets +append`.

--- a/crates/google-workspace-cli/src/helpers/sheets.rs
+++ b/crates/google-workspace-cli/src/helpers/sheets.rs
@@ -43,13 +43,15 @@ impl Helper for SheetsHelper {
                     Arg::new("values")
                         .long("values")
                         .help("Comma-separated values (simple strings)")
-                        .value_name("VALUES"),
+                        .value_name("VALUES")
+                        .required_unless_present("json-values"),
                 )
                 .arg(
                     Arg::new("json-values")
                         .long("json-values")
                         .help("JSON array of rows, e.g. '[[\"a\",\"b\"],[\"c\",\"d\"]]'")
-                        .value_name("JSON"),
+                        .value_name("JSON")
+                        .required_unless_present("values"),
                 )
                 .arg(
                     Arg::new("range")
@@ -521,5 +523,21 @@ mod tests {
         let subcommands: Vec<_> = cmd.get_subcommands().map(|s| s.get_name()).collect();
         assert!(subcommands.contains(&"+append"));
         assert!(subcommands.contains(&"+read"));
+    }
+
+    #[test]
+    fn test_append_requires_values_or_json_values() {
+        let helper = SheetsHelper;
+        let cmd = helper.inject_commands(
+            Command::new("sheets"),
+            &crate::discovery::RestDescription::default(),
+        );
+
+        let result = cmd.try_get_matches_from(["sheets", "+append", "--spreadsheet", "123"]);
+
+        assert!(
+            result.is_err(),
+            "+append should require --values or --json-values"
+        );
     }
 }

--- a/crates/google-workspace-cli/src/helpers/sheets.rs
+++ b/crates/google-workspace-cli/src/helpers/sheets.rs
@@ -535,12 +535,11 @@ mod tests {
             &crate::discovery::RestDescription::default(),
         );
 
-        let result = cmd.try_get_matches_from(["sheets", "+append", "--spreadsheet", "123"]);
+        let err = cmd
+            .try_get_matches_from(["sheets", "+append", "--spreadsheet", "123"])
+            .unwrap_err();
 
-        assert!(
-            result.is_err(),
-            "+append should require --values or --json-values"
-        );
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
     }
 
     #[test]

--- a/crates/google-workspace-cli/src/helpers/sheets.rs
+++ b/crates/google-workspace-cli/src/helpers/sheets.rs
@@ -44,14 +44,16 @@ impl Helper for SheetsHelper {
                         .long("values")
                         .help("Comma-separated values (simple strings)")
                         .value_name("VALUES")
-                        .required_unless_present("json-values"),
+                        .required_unless_present("json-values")
+                        .conflicts_with("json-values"),
                 )
                 .arg(
                     Arg::new("json-values")
                         .long("json-values")
                         .help("JSON array of rows, e.g. '[[\"a\",\"b\"],[\"c\",\"d\"]]'")
                         .value_name("JSON")
-                        .required_unless_present("values"),
+                        .required_unless_present("values")
+                        .conflicts_with("values"),
                 )
                 .arg(
                     Arg::new("range")
@@ -539,5 +541,29 @@ mod tests {
             result.is_err(),
             "+append should require --values or --json-values"
         );
+    }
+
+    #[test]
+    fn test_append_rejects_values_and_json_values_together() {
+        let helper = SheetsHelper;
+        let cmd = helper.inject_commands(
+            Command::new("sheets"),
+            &crate::discovery::RestDescription::default(),
+        );
+
+        let err = cmd
+            .try_get_matches_from([
+                "sheets",
+                "+append",
+                "--spreadsheet",
+                "123",
+                "--values",
+                "a,b",
+                "--json-values",
+                r#"["c","d"]"#,
+            ])
+            .unwrap_err();
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 }


### PR DESCRIPTION
## Description

`gws sheets +append` should only run when there is row data to append. Previously, the helper accepted a command with only `--spreadsheet`, which built an empty append request.

This PR makes `+append` require either `--values` or `--json-values` during argument parsing, so users get a clear CLI error before any API request is prepared.

**Dry Run Output:**
```json
// Not applicable: this validates required input before request creation.
```

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings. See testing note below.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.

## Testing

- `cargo fmt --all --check`
- `cargo test -q`
- `cargo clippy -- -D warnings` is blocked locally by a pre-existing `script.rs` clippy warning on current `main`; that warning is fixed separately in #786.
