### PR TITLE
fix(auth): include Gmail settings scope

### DIFF
--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -859,14 +859,20 @@ fn filter_redundant_restrictive_scopes(scopes: Vec<String>) -> Vec<String> {
     // broader scopes. Each entry maps a restrictive scope to the broader scopes
     // that make it redundant. The restrictive scope is removed only if at least
     // one of its broader alternatives is already in the list.
-    const RESTRICTIVE_SCOPES: &[(&str, &[&str])] = &[(
-        "https://www.googleapis.com/auth/gmail.metadata",
-        &[
-            "https://mail.google.com/",
-            "https://www.googleapis.com/auth/gmail.modify",
-            "https://www.googleapis.com/auth/gmail.readonly",
-        ],
-    )];
+    const RESTRICTIVE_SCOPES: &[(&str, &[&str])] = &[
+        (
+            "https://www.googleapis.com/auth/gmail.metadata",
+            &[
+                "https://mail.google.com/",
+                "https://www.googleapis.com/auth/gmail.modify",
+                "https://www.googleapis.com/auth/gmail.readonly",
+            ],
+        ),
+        (
+            "https://www.googleapis.com/auth/gmail.settings.basic",
+            &["https://mail.google.com/"],
+        ),
+    ];
 
     let scope_set: std::collections::HashSet<String> = scopes.iter().cloned().collect();
 
@@ -2367,6 +2373,26 @@ mod tests {
         let scopes = vec![
             "https://www.googleapis.com/auth/gmail.metadata".to_string(),
             "https://www.googleapis.com/auth/drive".to_string(),
+        ];
+        let result = filter_redundant_restrictive_scopes(scopes.clone());
+        assert_eq!(result, scopes);
+    }
+
+    #[test]
+    fn filter_restrictive_removes_settings_basic_when_full_gmail_present() {
+        let scopes = vec![
+            "https://mail.google.com/".to_string(),
+            "https://www.googleapis.com/auth/gmail.settings.basic".to_string(),
+        ];
+        let result = filter_redundant_restrictive_scopes(scopes);
+        assert_eq!(result, vec!["https://mail.google.com/"]);
+    }
+
+    #[test]
+    fn filter_restrictive_keeps_settings_basic_without_full_gmail() {
+        let scopes = vec![
+            "https://www.googleapis.com/auth/gmail.modify".to_string(),
+            "https://www.googleapis.com/auth/gmail.settings.basic".to_string(),
         ];
         let result = filter_redundant_restrictive_scopes(scopes.clone());
         assert_eq!(result, scopes);

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -264,7 +264,6 @@ pub const MINIMAL_SCOPES: &[&str] = &[
     "https://www.googleapis.com/auth/drive",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/gmail.modify",
-    "https://www.googleapis.com/auth/gmail.settings.basic",
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/documents",
     "https://www.googleapis.com/auth/presentations",
@@ -1758,7 +1757,7 @@ mod tests {
         assert_eq!(scopes.len(), DEFAULT_SCOPES.len());
         assert_eq!(scopes[0], "https://www.googleapis.com/auth/drive");
         assert!(
-            scopes.contains(&"https://www.googleapis.com/auth/gmail.settings.basic".to_string())
+            !scopes.contains(&"https://www.googleapis.com/auth/gmail.settings.basic".to_string())
         );
     }
 

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -264,6 +264,7 @@ pub const MINIMAL_SCOPES: &[&str] = &[
     "https://www.googleapis.com/auth/drive",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.settings.basic",
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/documents",
     "https://www.googleapis.com/auth/presentations",
@@ -289,6 +290,7 @@ pub const FULL_SCOPES: &[&str] = &[
     "https://www.googleapis.com/auth/drive",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.settings.basic",
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/documents",
     "https://www.googleapis.com/auth/presentations",
@@ -1550,6 +1552,10 @@ const SCOPE_ENTRIES: &[ScopeEntry] = &[
         label: "Gmail",
     },
     ScopeEntry {
+        scope: "https://www.googleapis.com/auth/gmail.settings.basic",
+        label: "Gmail Settings",
+    },
+    ScopeEntry {
         scope: "https://www.googleapis.com/auth/calendar",
         label: "Google Calendar",
     },
@@ -1745,6 +1751,9 @@ mod tests {
         let scopes = run_resolve_scopes(ScopeMode::Default, None);
         assert_eq!(scopes.len(), DEFAULT_SCOPES.len());
         assert_eq!(scopes[0], "https://www.googleapis.com/auth/drive");
+        assert!(
+            scopes.contains(&"https://www.googleapis.com/auth/gmail.settings.basic".to_string())
+        );
     }
 
     #[test]
@@ -1789,6 +1798,9 @@ mod tests {
     fn resolve_scopes_full_returns_full_scopes() {
         let scopes = run_resolve_scopes(ScopeMode::Full, None);
         assert_eq!(scopes.len(), FULL_SCOPES.len());
+        assert!(
+            scopes.contains(&"https://www.googleapis.com/auth/gmail.settings.basic".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #668.

## Summary
- add `https://www.googleapis.com/auth/gmail.settings.basic` to the minimal and full OAuth scope sets
- expose the same scope in the manual scope picker
- add coverage to keep the settings scope present

## Testing
- git diff --check
- cargo fmt --check
- cargo test -p google-workspace-cli resolve_scopes_returns_defaults_when_no_flag
- cargo test -p google-workspace-cli filter_restrictive