### PR TITLE
docs: fix save email attachments recipe

### DIFF
--- a/crates/google-workspace-cli/registry/recipes.toml
+++ b/crates/google-workspace-cli/registry/recipes.toml
@@ -322,8 +322,8 @@ services = [ "gmail", "drive" ]
 steps = [
   "Search for emails with attachments: `gws gmail users messages list --params '{\"userId\": \"me\", \"q\": \"has:attachment from:client@example.com\"}' --format table`",
   "Get message details: `gws gmail users messages get --params '{\"userId\": \"me\", \"id\": \"MESSAGE_ID\"}'`",
-  "Download attachment: `gws gmail users messages attachments get --params '{\"userId\": \"me\", \"messageId\": \"MESSAGE_ID\", \"id\": \"ATTACHMENT_ID\"}'`",
-  "Upload to Drive folder: `gws drive +upload --file ./attachment.pdf --parent FOLDER_ID`"
+  "Download and decode attachment bytes: `gws gmail users messages attachments get --params '{\"userId\": \"me\", \"messageId\": \"MESSAGE_ID\", \"id\": \"ATTACHMENT_ID\"}' | jq -r '.data' | python3 -c 'import base64,sys; d=sys.stdin.read().strip(); sys.stdout.buffer.write(base64.urlsafe_b64decode(d + \"=\" * (-len(d) % 4)))' > attachment.pdf`",
+  "Upload to Drive folder: `gws drive +upload ./attachment.pdf --parent FOLDER_ID`"
 ]
 
 [[recipes]]

--- a/skills/recipe-save-email-attachments/SKILL.md
+++ b/skills/recipe-save-email-attachments/SKILL.md
@@ -24,6 +24,11 @@ Find Gmail messages with attachments and save them to a Google Drive folder.
 
 1. Search for emails with attachments: `gws gmail users messages list --params '{"userId": "me", "q": "has:attachment from:client@example.com"}' --format table`
 2. Get message details: `gws gmail users messages get --params '{"userId": "me", "id": "MESSAGE_ID"}'`
-3. Download attachment: `gws gmail users messages attachments get --params '{"userId": "me", "messageId": "MESSAGE_ID", "id": "ATTACHMENT_ID"}'`
-4. Upload to Drive folder: `gws drive +upload --file ./attachment.pdf --parent FOLDER_ID`
-
+3. Download and decode attachment bytes:
+   ```bash
+   gws gmail users messages attachments get --params '{"userId": "me", "messageId": "MESSAGE_ID", "id": "ATTACHMENT_ID"}' \
+     | jq -r '.data' \
+     | python3 -c 'import base64,sys; d=sys.stdin.read().strip(); sys.stdout.buffer.write(base64.urlsafe_b64decode(d + "=" * (-len(d) % 4)))' \
+     > attachment.pdf
+   ```
+4. Upload to Drive folder: `gws drive +upload ./attachment.pdf --parent FOLDER_ID`


### PR DESCRIPTION
Closes #713.

## Summary
- update the recipe to decode Gmail attachment `data` into bytes before upload
- replace the invalid `gws drive +upload --file` invocation with the documented positional file form
- align the registry example with the corrected recipe

## Testing
- git diff --check
- python3 base64url decode smoke test