### PR TITLE
fix(errors): include retry-after in api errors

### DIFF
--- a/crates/google-workspace-cli/src/error.rs
+++ b/crates/google-workspace-cli/src/error.rs
@@ -120,6 +120,7 @@ mod tests {
             message: "bad".to_string(),
             reason: "r".to_string(),
             enable_url: None,
+            retry_after: None,
         };
         let label = error_label(&api_err);
         assert!(label.contains("error[api]:"));

--- a/crates/google-workspace-cli/src/executor.rs
+++ b/crates/google-workspace-cli/src/executor.rs
@@ -462,6 +462,11 @@ pub async fn execute_method(
             .and_then(|v| v.to_str().ok())
             .unwrap_or("")
             .to_string();
+        let retry_after = response
+            .headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
 
         if !status.is_success() {
             let error_body = response.text().await.unwrap_or_default();
@@ -472,7 +477,7 @@ pub async fn execute_method(
                 latency_ms = latency_ms,
                 "API error"
             );
-            return handle_error_response(status, &error_body, &auth_method);
+            return handle_error_response(status, &error_body, &auth_method, retry_after);
         }
 
         tracing::debug!(
@@ -754,6 +759,7 @@ fn handle_error_response<T>(
     status: reqwest::StatusCode,
     error_body: &str,
     auth_method: &AuthMethod,
+    retry_after: Option<String>,
 ) -> Result<T, GwsError> {
     // If 401/403 and no auth was provided, give a helpful message
     if (status.as_u16() == 401 || status.as_u16() == 403) && *auth_method == AuthMethod::None {
@@ -800,6 +806,7 @@ fn handle_error_response<T>(
                 message,
                 reason,
                 enable_url,
+                retry_after,
             });
         }
     }
@@ -809,6 +816,7 @@ fn handle_error_response<T>(
         message: error_body.to_string(),
         reason: "httpError".to_string(),
         enable_url: None,
+        retry_after,
     })
 }
 
@@ -1947,6 +1955,7 @@ mod tests {
             reqwest::StatusCode::UNAUTHORIZED,
             "Unauthorized",
             &AuthMethod::None,
+            None,
         )
         .unwrap_err();
         match err {
@@ -1973,6 +1982,7 @@ mod tests {
             reqwest::StatusCode::UNAUTHORIZED,
             &json_err,
             &AuthMethod::OAuth,
+            None,
         )
         .unwrap_err();
         match err {
@@ -2008,6 +2018,7 @@ mod tests {
             reqwest::StatusCode::BAD_REQUEST,
             &json_err,
             &AuthMethod::OAuth,
+            None,
         )
         .unwrap_err();
         match err {
@@ -2021,6 +2032,31 @@ mod tests {
                 assert_eq!(message, "Bad Request");
                 assert_eq!(reason, "bad");
             }
+            _ => panic!("Expected Api error"),
+        }
+    }
+
+    #[test]
+    fn test_handle_error_response_preserves_retry_after_header() {
+        let json_err = json!({
+            "error": {
+                "code": 429,
+                "message": "Quota exceeded",
+                "errors": [{ "reason": "rateLimitExceeded" }]
+            }
+        })
+        .to_string();
+
+        let err = handle_error_response::<()>(
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            &json_err,
+            &AuthMethod::OAuth,
+            Some("120".to_string()),
+        )
+        .unwrap_err();
+
+        match err {
+            GwsError::Api { retry_after, .. } => assert_eq!(retry_after.as_deref(), Some("120")),
             _ => panic!("Expected Api error"),
         }
     }
@@ -2156,6 +2192,7 @@ fn test_handle_error_response_non_json() {
         reqwest::StatusCode::INTERNAL_SERVER_ERROR,
         "Internal Server Error Text",
         &AuthMethod::OAuth,
+        None,
     )
     .unwrap_err();
     match err {
@@ -2223,6 +2260,7 @@ fn test_handle_error_response_access_not_configured_with_url() {
         reqwest::StatusCode::FORBIDDEN,
         &json_err,
         &AuthMethod::OAuth,
+        None,
     )
     .unwrap_err();
 
@@ -2260,6 +2298,7 @@ fn test_handle_error_response_access_not_configured_errors_array() {
         reqwest::StatusCode::FORBIDDEN,
         &json_err,
         &AuthMethod::OAuth,
+        None,
     )
     .unwrap_err();
 

--- a/crates/google-workspace-cli/src/executor.rs
+++ b/crates/google-workspace-cli/src/executor.rs
@@ -462,11 +462,7 @@ pub async fn execute_method(
             .and_then(|v| v.to_str().ok())
             .unwrap_or("")
             .to_string();
-        let retry_after = response
-            .headers()
-            .get(reqwest::header::RETRY_AFTER)
-            .and_then(|v| v.to_str().ok())
-            .map(str::to_string);
+        let retry_after = retry_after_header(&response);
 
         if !status.is_success() {
             let error_body = response.text().await.unwrap_or_default();
@@ -753,6 +749,13 @@ pub fn extract_enable_url(message: &str) -> Option<String> {
         })
         .filter(|s| s.starts_with("http"))?;
     Some(url.to_string())
+}
+
+pub fn retry_after_header(resp: &reqwest::Response) -> Option<String> {
+    resp.headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string)
 }
 
 fn handle_error_response<T>(

--- a/crates/google-workspace-cli/src/helpers/calendar.rs
+++ b/crates/google-workspace-cli/src/helpers/calendar.rs
@@ -274,6 +274,7 @@ async fn handle_agenda(matches: &ArgMatches) -> Result<(), GwsError> {
             message: err,
             reason: "calendarList_failed".to_string(),
             enable_url: None,
+            retry_after: None,
         });
     }
 

--- a/crates/google-workspace-cli/src/helpers/calendar.rs
+++ b/crates/google-workspace-cli/src/helpers/calendar.rs
@@ -268,13 +268,15 @@ async fn handle_agenda(matches: &ArgMatches) -> Result<(), GwsError> {
         .map_err(|e| GwsError::Other(anyhow::anyhow!("Failed to list calendars: {e}")))?;
 
     if !list_resp.status().is_success() {
+        let status = list_resp.status();
+        let retry_after = crate::executor::retry_after_header(&list_resp);
         let err = list_resp.text().await.unwrap_or_default();
         return Err(GwsError::Api {
-            code: 0,
+            code: status.as_u16(),
             message: err,
             reason: "calendarList_failed".to_string(),
             enable_url: None,
-            retry_after: None,
+            retry_after,
         });
     }
 

--- a/crates/google-workspace-cli/src/helpers/events/subscribe.rs
+++ b/crates/google-workspace-cli/src/helpers/events/subscribe.rs
@@ -221,6 +221,7 @@ pub(super) async fn handle_subscribe(
                     message: format!("Failed to create Pub/Sub topic: {body}"),
                     reason: "pubsubError".to_string(),
                     enable_url: None,
+                    retry_after: None,
                 });
             }
 
@@ -246,6 +247,7 @@ pub(super) async fn handle_subscribe(
                     message: format!("Failed to create Pub/Sub subscription: {body}"),
                     reason: "pubsubError".to_string(),
                     enable_url: None,
+                    retry_after: None,
                 });
             }
 
@@ -421,6 +423,7 @@ async fn pull_loop(
                 message: format!("Pub/Sub pull failed: {body}"),
                 reason: "pubsubError".to_string(),
                 enable_url: None,
+                retry_after: None,
             });
         }
 

--- a/crates/google-workspace-cli/src/helpers/events/subscribe.rs
+++ b/crates/google-workspace-cli/src/helpers/events/subscribe.rs
@@ -215,13 +215,14 @@ pub(super) async fn handle_subscribe(
                 .context("Failed to create topic")?;
 
             if !resp.status().is_success() {
+                let retry_after = crate::executor::retry_after_header(&resp);
                 let body = resp.text().await.unwrap_or_default();
                 return Err(GwsError::Api {
                     code: 400,
                     message: format!("Failed to create Pub/Sub topic: {body}"),
                     reason: "pubsubError".to_string(),
                     enable_url: None,
-                    retry_after: None,
+                    retry_after,
                 });
             }
 
@@ -241,13 +242,14 @@ pub(super) async fn handle_subscribe(
                 .context("Failed to create subscription")?;
 
             if !resp.status().is_success() {
+                let retry_after = crate::executor::retry_after_header(&resp);
                 let body = resp.text().await.unwrap_or_default();
                 return Err(GwsError::Api {
                     code: 400,
                     message: format!("Failed to create Pub/Sub subscription: {body}"),
                     reason: "pubsubError".to_string(),
                     enable_url: None,
-                    retry_after: None,
+                    retry_after,
                 });
             }
 
@@ -417,13 +419,14 @@ async fn pull_loop(
         };
 
         if !resp.status().is_success() {
+            let retry_after = crate::executor::retry_after_header(&resp);
             let body = resp.text().await.unwrap_or_default();
             return Err(GwsError::Api {
                 code: 400,
                 message: format!("Pub/Sub pull failed: {body}"),
                 reason: "pubsubError".to_string(),
                 enable_url: None,
-                retry_after: None,
+                retry_after,
             });
         }
 

--- a/crates/google-workspace-cli/src/helpers/gmail/mod.rs
+++ b/crates/google-workspace-cli/src/helpers/gmail/mod.rs
@@ -385,6 +385,7 @@ pub(super) async fn fetch_message_metadata(
 
     if !resp.status().is_success() {
         let status = resp.status().as_u16();
+        let retry_after = retry_after_header(&resp);
         let body = resp
             .text()
             .await
@@ -393,6 +394,7 @@ pub(super) async fn fetch_message_metadata(
             status,
             &body,
             &format!("Failed to fetch message {message_id}"),
+            retry_after,
         ));
     }
 
@@ -407,7 +409,12 @@ pub(super) async fn fetch_message_metadata(
 /// Build a `GwsError::Api` from an HTTP error response body, parsing the
 /// Google JSON error format when possible. Modeled after the executor's
 /// `handle_error_response`, extracting message, reason, and enable URL.
-pub(super) fn build_api_error(status: u16, body: &str, context: &str) -> GwsError {
+pub(super) fn build_api_error(
+    status: u16,
+    body: &str,
+    context: &str,
+    retry_after: Option<String>,
+) -> GwsError {
     let err_json: Option<Value> = serde_json::from_str(body).ok();
     let err_obj = err_json.as_ref().and_then(|v| v.get("error"));
     let message = err_obj
@@ -438,8 +445,15 @@ pub(super) fn build_api_error(status: u16, body: &str, context: &str) -> GwsErro
         message: format!("{context}: {message}"),
         reason,
         enable_url,
-        retry_after: None,
+        retry_after,
     }
+}
+
+pub(super) fn retry_after_header(resp: &reqwest::Response) -> Option<String> {
+    resp.headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string)
 }
 
 #[derive(Debug)]
@@ -463,6 +477,7 @@ async fn fetch_send_as_identities(
 
     if !resp.status().is_success() {
         let status = resp.status().as_u16();
+        let retry_after = retry_after_header(&resp);
         let body = resp
             .text()
             .await
@@ -471,6 +486,7 @@ async fn fetch_send_as_identities(
             status,
             &body,
             "Failed to fetch sendAs settings",
+            retry_after,
         ));
     }
 
@@ -657,11 +673,17 @@ async fn fetch_profile_display_name(
 
     if !resp.status().is_success() {
         let status = resp.status().as_u16();
+        let retry_after = retry_after_header(&resp);
         let body = resp
             .text()
             .await
             .unwrap_or_else(|_| "(error body unreadable)".to_string());
-        return Err(build_api_error(status, &body, "People API request failed"));
+        return Err(build_api_error(
+            status,
+            &body,
+            "People API request failed",
+            retry_after,
+        ));
     }
 
     let body: Value = resp.json().await.map_err(|e| {
@@ -704,6 +726,7 @@ async fn fetch_attachment_data(
 
     if !resp.status().is_success() {
         let status = resp.status().as_u16();
+        let retry_after = retry_after_header(&resp);
         let err = resp
             .text()
             .await
@@ -712,6 +735,7 @@ async fn fetch_attachment_data(
             status,
             &err,
             &format!("Failed to fetch attachment {attachment_id} from message {message_id}"),
+            retry_after,
         ));
     }
 
@@ -3608,7 +3632,7 @@ mod tests {
     #[test]
     fn test_build_api_error_parses_google_json_format() {
         let body = r#"{"error":{"code":403,"message":"Insufficient Permission","errors":[{"reason":"insufficientPermissions","domain":"global","message":"Insufficient Permission"}]}}"#;
-        let err = build_api_error(403, body, "Test context");
+        let err = build_api_error(403, body, "Test context", None);
         match err {
             GwsError::Api {
                 code,
@@ -3629,7 +3653,7 @@ mod tests {
 
     #[test]
     fn test_build_api_error_falls_back_to_raw_body() {
-        let err = build_api_error(500, "Internal Server Error", "Test context");
+        let err = build_api_error(500, "Internal Server Error", "Test context", None);
         match err {
             GwsError::Api {
                 code,
@@ -3646,9 +3670,19 @@ mod tests {
     }
 
     #[test]
+    fn test_build_api_error_preserves_retry_after() {
+        let body = r#"{"error":{"code":429,"message":"Quota exceeded","errors":[{"reason":"rateLimitExceeded"}]}}"#;
+        let err = build_api_error(429, body, "ctx", Some("60".to_string()));
+        match err {
+            GwsError::Api { retry_after, .. } => assert_eq!(retry_after.as_deref(), Some("60")),
+            _ => panic!("Expected GwsError::Api"),
+        }
+    }
+
+    #[test]
     fn test_build_api_error_extracts_top_level_reason() {
         let body = r#"{"error":{"code":404,"message":"Not Found","reason":"notFound"}}"#;
-        let err = build_api_error(404, body, "ctx");
+        let err = build_api_error(404, body, "ctx", None);
         match err {
             GwsError::Api { reason, .. } => assert_eq!(reason, "notFound"),
             _ => panic!("Expected GwsError::Api"),
@@ -3658,7 +3692,7 @@ mod tests {
     #[test]
     fn test_build_api_error_access_not_configured_extracts_url() {
         let body = r#"{"error":{"code":403,"message":"People API has not been used in project 123 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/people.googleapis.com/overview?project=123 then retry.","errors":[{"reason":"accessNotConfigured"}]}}"#;
-        let err = build_api_error(403, body, "ctx");
+        let err = build_api_error(403, body, "ctx", None);
         match err {
             GwsError::Api {
                 reason, enable_url, ..

--- a/crates/google-workspace-cli/src/helpers/gmail/mod.rs
+++ b/crates/google-workspace-cli/src/helpers/gmail/mod.rs
@@ -438,6 +438,7 @@ pub(super) fn build_api_error(status: u16, body: &str, context: &str) -> GwsErro
         message: format!("{context}: {message}"),
         reason,
         enable_url,
+        retry_after: None,
     }
 }
 
@@ -3614,6 +3615,7 @@ mod tests {
                 message,
                 reason,
                 enable_url,
+                ..
             } => {
                 assert_eq!(code, 403);
                 assert!(message.contains("Test context"));

--- a/crates/google-workspace-cli/src/helpers/gmail/mod.rs
+++ b/crates/google-workspace-cli/src/helpers/gmail/mod.rs
@@ -30,6 +30,7 @@ use watch::handle_watch;
 pub(super) use crate::auth;
 pub(super) use crate::error::GwsError;
 pub(super) use crate::executor;
+pub(super) use crate::executor::retry_after_header;
 use crate::output::sanitize_for_terminal;
 pub(super) use anyhow::Context;
 pub(super) use base64::{engine::general_purpose::URL_SAFE, Engine as _};
@@ -447,13 +448,6 @@ pub(super) fn build_api_error(
         enable_url,
         retry_after,
     }
-}
-
-pub(super) fn retry_after_header(resp: &reqwest::Response) -> Option<String> {
-    resp.headers()
-        .get(reqwest::header::RETRY_AFTER)
-        .and_then(|value| value.to_str().ok())
-        .map(str::to_string)
 }
 
 #[derive(Debug)]

--- a/crates/google-workspace-cli/src/helpers/gmail/reply.rs
+++ b/crates/google-workspace-cli/src/helpers/gmail/reply.rs
@@ -185,6 +185,7 @@ async fn fetch_user_email(client: &reqwest::Client, token: &str) -> Result<Strin
 
     if !resp.status().is_success() {
         let status = resp.status().as_u16();
+        let retry_after = super::retry_after_header(&resp);
         let body = resp
             .text()
             .await
@@ -193,6 +194,7 @@ async fn fetch_user_email(client: &reqwest::Client, token: &str) -> Result<Strin
             status,
             &body,
             "Failed to fetch user profile",
+            retry_after,
         ));
     }
 

--- a/crates/google-workspace-cli/src/helpers/gmail/triage.rs
+++ b/crates/google-workspace-cli/src/helpers/gmail/triage.rs
@@ -65,6 +65,7 @@ pub async fn handle_triage(matches: &ArgMatches) -> Result<(), GwsError> {
             message: err,
             reason: "list_failed".to_string(),
             enable_url: None,
+            retry_after: None,
         });
     }
 

--- a/crates/google-workspace-cli/src/helpers/gmail/triage.rs
+++ b/crates/google-workspace-cli/src/helpers/gmail/triage.rs
@@ -59,13 +59,14 @@ pub async fn handle_triage(matches: &ArgMatches) -> Result<(), GwsError> {
         .map_err(|e| GwsError::Other(anyhow::anyhow!("Failed to list messages: {e}")))?;
 
     if !list_resp.status().is_success() {
+        let retry_after = super::retry_after_header(&list_resp);
         let err = list_resp.text().await.unwrap_or_default();
         return Err(GwsError::Api {
             code: 0,
             message: err,
             reason: "list_failed".to_string(),
             enable_url: None,
-            retry_after: None,
+            retry_after,
         });
     }
 

--- a/crates/google-workspace-cli/src/helpers/gmail/watch.rs
+++ b/crates/google-workspace-cli/src/helpers/gmail/watch.rs
@@ -61,13 +61,14 @@ pub(super) async fn handle_watch(
                 .context("Failed to create topic")?;
 
             if !resp.status().is_success() {
+                let retry_after = super::retry_after_header(&resp);
                 let body = resp.text().await.unwrap_or_default();
                 return Err(GwsError::Api {
                     code: 400,
                     message: format!("Failed to create Pub/Sub topic: {body}"),
                     reason: "pubsubError".to_string(),
                     enable_url: None,
-                    retry_after: None,
+                    retry_after,
                 });
             }
 
@@ -127,13 +128,14 @@ pub(super) async fn handle_watch(
             .context("Failed to create subscription")?;
 
         if !resp.status().is_success() {
+            let retry_after = super::retry_after_header(&resp);
             let body = resp.text().await.unwrap_or_default();
             return Err(GwsError::Api {
                 code: 400,
                 message: format!("Failed to create Pub/Sub subscription: {body}"),
                 reason: "pubsubError".to_string(),
                 enable_url: None,
-                retry_after: None,
+                retry_after,
             });
         }
 
@@ -156,6 +158,7 @@ pub(super) async fn handle_watch(
             .await
             .context("Failed to call gmail.users.watch")?;
 
+        let retry_after = super::retry_after_header(&resp);
         let watch_resp: Value = resp
             .json()
             .await
@@ -170,7 +173,7 @@ pub(super) async fn handle_watch(
                 ),
                 reason: "gmailError".to_string(),
                 enable_url: None,
-                retry_after: None,
+                retry_after,
             });
         }
 
@@ -298,13 +301,14 @@ async fn watch_pull_loop(
         };
 
         if !resp.status().is_success() {
+            let retry_after = super::retry_after_header(&resp);
             let body = resp.text().await.unwrap_or_default();
             return Err(GwsError::Api {
                 code: 400,
                 message: format!("Pub/Sub pull failed: {body}"),
                 reason: "pubsubError".to_string(),
                 enable_url: None,
-                retry_after: None,
+                retry_after,
             });
         }
 

--- a/crates/google-workspace-cli/src/helpers/gmail/watch.rs
+++ b/crates/google-workspace-cli/src/helpers/gmail/watch.rs
@@ -67,6 +67,7 @@ pub(super) async fn handle_watch(
                     message: format!("Failed to create Pub/Sub topic: {body}"),
                     reason: "pubsubError".to_string(),
                     enable_url: None,
+                    retry_after: None,
                 });
             }
 
@@ -132,6 +133,7 @@ pub(super) async fn handle_watch(
                 message: format!("Failed to create Pub/Sub subscription: {body}"),
                 reason: "pubsubError".to_string(),
                 enable_url: None,
+                retry_after: None,
             });
         }
 
@@ -168,6 +170,7 @@ pub(super) async fn handle_watch(
                 ),
                 reason: "gmailError".to_string(),
                 enable_url: None,
+                retry_after: None,
             });
         }
 
@@ -301,6 +304,7 @@ async fn watch_pull_loop(
                 message: format!("Pub/Sub pull failed: {body}"),
                 reason: "pubsubError".to_string(),
                 enable_url: None,
+                retry_after: None,
             });
         }
 

--- a/crates/google-workspace-cli/src/helpers/workflows.rs
+++ b/crates/google-workspace-cli/src/helpers/workflows.rs
@@ -251,6 +251,7 @@ async fn get_json(
             message: body,
             reason: "workflow_request_failed".to_string(),
             enable_url: None,
+            retry_after: None,
         });
     }
 
@@ -517,6 +518,7 @@ async fn handle_email_to_task(matches: &ArgMatches) -> Result<(), GwsError> {
             message: body,
             reason: "task_create_failed".to_string(),
             enable_url: None,
+            retry_after: None,
         });
     }
 
@@ -676,6 +678,7 @@ async fn handle_file_announce(matches: &ArgMatches) -> Result<(), GwsError> {
             message: body,
             reason: "chat_send_failed".to_string(),
             enable_url: None,
+            retry_after: None,
         });
     }
 

--- a/crates/google-workspace-cli/src/helpers/workflows.rs
+++ b/crates/google-workspace-cli/src/helpers/workflows.rs
@@ -245,13 +245,14 @@ async fn get_json(
 
     if !resp.status().is_success() {
         let status = resp.status();
+        let retry_after = crate::executor::retry_after_header(&resp);
         let body = resp.text().await.unwrap_or_default();
         return Err(GwsError::Api {
             code: status.as_u16(),
             message: body,
             reason: "workflow_request_failed".to_string(),
             enable_url: None,
-            retry_after: None,
+            retry_after,
         });
     }
 
@@ -512,13 +513,14 @@ async fn handle_email_to_task(matches: &ArgMatches) -> Result<(), GwsError> {
 
     if !resp.status().is_success() {
         let status = resp.status();
+        let retry_after = crate::executor::retry_after_header(&resp);
         let body = resp.text().await.unwrap_or_default();
         return Err(GwsError::Api {
             code: status.as_u16(),
             message: body,
             reason: "task_create_failed".to_string(),
             enable_url: None,
-            retry_after: None,
+            retry_after,
         });
     }
 
@@ -672,13 +674,14 @@ async fn handle_file_announce(matches: &ArgMatches) -> Result<(), GwsError> {
 
     if !chat_resp.status().is_success() {
         let status = chat_resp.status();
+        let retry_after = crate::executor::retry_after_header(&chat_resp);
         let body = chat_resp.text().await.unwrap_or_default();
         return Err(GwsError::Api {
             code: status.as_u16(),
             message: body,
             reason: "chat_send_failed".to_string(),
             enable_url: None,
-            retry_after: None,
+            retry_after,
         });
     }
 

--- a/crates/google-workspace-cli/src/timezone.rs
+++ b/crates/google-workspace-cli/src/timezone.rs
@@ -86,13 +86,14 @@ async fn fetch_account_timezone(client: &reqwest::Client, token: &str) -> Result
 
     if !resp.status().is_success() {
         let status = resp.status();
+        let retry_after = crate::executor::retry_after_header(&resp);
         let body = resp.text().await.unwrap_or_default();
         return Err(GwsError::Api {
             code: status.as_u16(),
             message: body,
             reason: "timezone_fetch_failed".to_string(),
             enable_url: None,
-            retry_after: None,
+            retry_after,
         });
     }
 

--- a/crates/google-workspace-cli/src/timezone.rs
+++ b/crates/google-workspace-cli/src/timezone.rs
@@ -92,6 +92,7 @@ async fn fetch_account_timezone(client: &reqwest::Client, token: &str) -> Result
             message: body,
             reason: "timezone_fetch_failed".to_string(),
             enable_url: None,
+            retry_after: None,
         });
     }
 

--- a/crates/google-workspace/src/error.rs
+++ b/crates/google-workspace/src/error.rs
@@ -26,6 +26,8 @@ pub enum GwsError {
         reason: String,
         /// For `accessNotConfigured` errors: the GCP console URL to enable the API.
         enable_url: Option<String>,
+        /// Raw Retry-After response header, when provided by the API.
+        retry_after: Option<String>,
     },
 
     #[error("{0}")]
@@ -71,6 +73,7 @@ impl GwsError {
                 message,
                 reason,
                 enable_url,
+                retry_after,
             } => {
                 let mut error_obj = json!({
                     "code": code,
@@ -79,6 +82,9 @@ impl GwsError {
                 });
                 if let Some(url) = enable_url {
                     error_obj["enable_url"] = json!(url);
+                }
+                if let Some(value) = retry_after {
+                    error_obj["retry_after"] = json!(value);
                 }
                 json!({ "error": error_obj })
             }
@@ -125,6 +131,7 @@ mod tests {
             message: "Not Found".to_string(),
             reason: "notFound".to_string(),
             enable_url: None,
+            retry_after: None,
         };
         assert_eq!(err.exit_code(), GwsError::EXIT_CODE_API);
     }
@@ -185,12 +192,26 @@ mod tests {
             message: "Not Found".to_string(),
             reason: "notFound".to_string(),
             enable_url: None,
+            retry_after: None,
         };
         let json = err.to_json();
         assert_eq!(json["error"]["code"], 404);
         assert_eq!(json["error"]["message"], "Not Found");
         assert_eq!(json["error"]["reason"], "notFound");
         assert!(json["error"]["enable_url"].is_null());
+    }
+
+    #[test]
+    fn test_error_to_json_api_includes_retry_after() {
+        let err = GwsError::Api {
+            code: 429,
+            message: "Quota exceeded".to_string(),
+            reason: "rateLimitExceeded".to_string(),
+            enable_url: None,
+            retry_after: Some("120".to_string()),
+        };
+        let json = err.to_json();
+        assert_eq!(json["error"]["retry_after"], "120");
     }
 
     #[test]
@@ -236,6 +257,7 @@ mod tests {
             message: "Gmail API has not been used in project 549352339482 before or it is disabled.".to_string(),
             reason: "accessNotConfigured".to_string(),
             enable_url: Some("https://console.developers.google.com/apis/api/gmail.googleapis.com/overview?project=549352339482".to_string()),
+            retry_after: None,
         };
         let json = err.to_json();
         assert_eq!(json["error"]["code"], 403);
@@ -253,6 +275,7 @@ mod tests {
             message: "API not enabled.".to_string(),
             reason: "accessNotConfigured".to_string(),
             enable_url: None,
+            retry_after: None,
         };
         let json = err.to_json();
         assert_eq!(json["error"]["code"], 403);


### PR DESCRIPTION
Fixes #777.

## Summary
- capture the HTTP `Retry-After` response header before consuming error responses
- carry the raw header through `GwsError::Api`
- include `error.retry_after` in JSON output when the API provides the header

## Tests
- `cargo fmt --check`
- `cargo test -p google-workspace test_error_to_json_api_includes_retry_after`
- `cargo test -p google-workspace-cli test_handle_error_response_preserves_retry_after_header`