### PR TITLE
feat(admin): add directory service alias

### DIFF
--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -841,6 +841,8 @@ fn map_service_to_scope_prefixes(service: &str) -> Vec<&str> {
         "slides" => vec!["presentations"],
         "docs" => vec!["documents"],
         "people" => vec!["contacts", "directory"],
+        "admin-directory" => vec!["admin.directory"],
+        "admin-reports" | "reports" => vec!["admin.reports"],
         s => vec![s],
     }
 }
@@ -2232,6 +2234,36 @@ mod tests {
         ));
         assert!(scope_matches_service(
             "https://www.googleapis.com/auth/chat.messages",
+            &services
+        ));
+    }
+
+    #[test]
+    fn scope_matches_admin_directory_service() {
+        let services: HashSet<String> = ["admin-directory"].iter().map(|s| s.to_string()).collect();
+        assert!(scope_matches_service(
+            "https://www.googleapis.com/auth/admin.directory.user.readonly",
+            &services
+        ));
+        assert!(scope_matches_service(
+            "https://www.googleapis.com/auth/admin.directory.group",
+            &services
+        ));
+        assert!(!scope_matches_service(
+            "https://www.googleapis.com/auth/admin.reports.audit.readonly",
+            &services
+        ));
+    }
+
+    #[test]
+    fn scope_matches_admin_reports_service() {
+        let services: HashSet<String> = ["admin-reports"].iter().map(|s| s.to_string()).collect();
+        assert!(scope_matches_service(
+            "https://www.googleapis.com/auth/admin.reports.audit.readonly",
+            &services
+        ));
+        assert!(!scope_matches_service(
+            "https://www.googleapis.com/auth/admin.directory.user.readonly",
             &services
         ));
     }

--- a/crates/google-workspace/src/services.rs
+++ b/crates/google-workspace/src/services.rs
@@ -59,6 +59,12 @@ pub const SERVICES: &[ServiceEntry] = &[
         description: "Audit logs and usage reports",
     },
     ServiceEntry {
+        aliases: &["admin-directory"],
+        api_name: "admin",
+        version: "directory_v1",
+        description: "Manage users, groups, and organizational units",
+    },
+    ServiceEntry {
         aliases: &["docs"],
         api_name: "docs",
         version: "v1",
@@ -173,6 +179,10 @@ mod tests {
         assert_eq!(
             resolve_service("reports").unwrap(),
             ("admin".to_string(), "reports_v1".to_string())
+        );
+        assert_eq!(
+            resolve_service("admin-directory").unwrap(),
+            ("admin".to_string(), "directory_v1".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary
- add `admin-directory` as a built-in alias for Admin SDK Directory API (`admin:directory_v1`)
- keep `admin-reports` mapped to `admin:reports_v1`
- teach service scope filtering to distinguish `admin.directory.*` from `admin.reports.*`

## Why
Directory workflows like listing users, groups, members, and organizational units currently require knowing to use `admin-reports --api-version directory_v1`, which is hard to discover and misleading. A dedicated alias makes common Workspace admin tasks easier to find and use.

Fixes #473.

## Tests
- `cargo fmt --check`
- `cargo test -p google-workspace services::tests::test_resolve_service_known`
- `cargo test -p google-workspace-cli scope_matches_admin`
- `cargo check -p google-workspace-cli`
- `git diff --check`
