### PR TITLE
fix(auth): expose Gmail settings scope

### DIFF
--- a/.changeset/gmail-settings-basic-scope.md
+++ b/.changeset/gmail-settings-basic-scope.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Expose the Gmail settings basic scope for full and manual auth flows.

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -289,6 +289,7 @@ pub const FULL_SCOPES: &[&str] = &[
     "https://www.googleapis.com/auth/drive",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.settings.basic",
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/documents",
     "https://www.googleapis.com/auth/presentations",
@@ -857,14 +858,20 @@ fn filter_redundant_restrictive_scopes(scopes: Vec<String>) -> Vec<String> {
     // broader scopes. Each entry maps a restrictive scope to the broader scopes
     // that make it redundant. The restrictive scope is removed only if at least
     // one of its broader alternatives is already in the list.
-    const RESTRICTIVE_SCOPES: &[(&str, &[&str])] = &[(
-        "https://www.googleapis.com/auth/gmail.metadata",
-        &[
-            "https://mail.google.com/",
-            "https://www.googleapis.com/auth/gmail.modify",
-            "https://www.googleapis.com/auth/gmail.readonly",
-        ],
-    )];
+    const RESTRICTIVE_SCOPES: &[(&str, &[&str])] = &[
+        (
+            "https://www.googleapis.com/auth/gmail.metadata",
+            &[
+                "https://mail.google.com/",
+                "https://www.googleapis.com/auth/gmail.modify",
+                "https://www.googleapis.com/auth/gmail.readonly",
+            ],
+        ),
+        (
+            "https://www.googleapis.com/auth/gmail.settings.basic",
+            &["https://mail.google.com/"],
+        ),
+    ];
 
     let scope_set: std::collections::HashSet<String> = scopes.iter().cloned().collect();
 
@@ -1550,6 +1557,10 @@ const SCOPE_ENTRIES: &[ScopeEntry] = &[
         label: "Gmail",
     },
     ScopeEntry {
+        scope: "https://www.googleapis.com/auth/gmail.settings.basic",
+        label: "Gmail Settings",
+    },
+    ScopeEntry {
         scope: "https://www.googleapis.com/auth/calendar",
         label: "Google Calendar",
     },
@@ -1745,6 +1756,9 @@ mod tests {
         let scopes = run_resolve_scopes(ScopeMode::Default, None);
         assert_eq!(scopes.len(), DEFAULT_SCOPES.len());
         assert_eq!(scopes[0], "https://www.googleapis.com/auth/drive");
+        assert!(
+            !scopes.contains(&"https://www.googleapis.com/auth/gmail.settings.basic".to_string())
+        );
     }
 
     #[test]
@@ -1789,6 +1803,9 @@ mod tests {
     fn resolve_scopes_full_returns_full_scopes() {
         let scopes = run_resolve_scopes(ScopeMode::Full, None);
         assert_eq!(scopes.len(), FULL_SCOPES.len());
+        assert!(
+            scopes.contains(&"https://www.googleapis.com/auth/gmail.settings.basic".to_string())
+        );
     }
 
     #[test]
@@ -2355,6 +2372,26 @@ mod tests {
         let scopes = vec![
             "https://www.googleapis.com/auth/gmail.metadata".to_string(),
             "https://www.googleapis.com/auth/drive".to_string(),
+        ];
+        let result = filter_redundant_restrictive_scopes(scopes.clone());
+        assert_eq!(result, scopes);
+    }
+
+    #[test]
+    fn filter_restrictive_removes_settings_basic_when_full_gmail_present() {
+        let scopes = vec![
+            "https://mail.google.com/".to_string(),
+            "https://www.googleapis.com/auth/gmail.settings.basic".to_string(),
+        ];
+        let result = filter_redundant_restrictive_scopes(scopes);
+        assert_eq!(result, vec!["https://mail.google.com/"]);
+    }
+
+    #[test]
+    fn filter_restrictive_keeps_settings_basic_with_gmail_modify() {
+        let scopes = vec![
+            "https://www.googleapis.com/auth/gmail.modify".to_string(),
+            "https://www.googleapis.com/auth/gmail.settings.basic".to_string(),
         ];
         let result = filter_redundant_restrictive_scopes(scopes.clone());
         assert_eq!(result, scopes);


### PR DESCRIPTION
## Summary
- add `https://www.googleapis.com/auth/gmail.settings.basic` to the `--full` auth scope set
- expose it in the manual scope picker as "Gmail Settings"
- keep it out of default/minimal scopes so first-run login stays conservative
- only filter it as redundant when `https://mail.google.com/` is also present; `gmail.modify` is intentionally not treated as a broader substitute
- add a patch changeset and regression coverage

This refreshes #794 with the conservative scope design kept explicit. Gmail settings endpoints such as filters.list require `gmail.settings.basic`: https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.settings.filters/list

## Testing
- cargo test -p google-workspace-cli settings_basic
- cargo test -p google-workspace-cli resolve_scopes
- git diff --cached --check