### PR TITLE
docs: add GEMINI.md mirroring CLAUDE.md

### DIFF
--- a/.changeset/add-gemini-md.md
+++ b/.changeset/add-gemini-md.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Add GEMINI.md to mirror CLAUDE.md for Gemini CLI tooling

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+When contributing to this repository, you must strictly follow all guidelines outlined in the AGENTS.md file.


### PR DESCRIPTION
## Summary

Adds `GEMINI.md` at the repo root with the same content as `CLAUDE.md`, directing Gemini CLI agents to follow `AGENTS.md` when contributing.

Closes #778

## Checklist
- [x] Changeset file added (`.changeset/add-gemini-md.md`, patch bump)
- [x] No code changes — documentation only