### PR TITLE
docs(skills): document gws-shared prerequisite for selective skill install

### DIFF
--- a/.changeset/fix-skill-install-docs.md
+++ b/.changeset/fix-skill-install-docs.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Document gws-shared as a required prerequisite for selective skill installation

--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ The repo ships 100+ Agent Skills (`SKILL.md` files) — one for every supported 
 npx skills add https://github.com/googleworkspace/cli
 
 # Or pick only what you need
+# gws-shared is required by all service skills — install it first
+npx skills add https://github.com/googleworkspace/cli/tree/main/skills/gws-shared
+
+# Then install the specific service skills you need
 npx skills add https://github.com/googleworkspace/cli/tree/main/skills/gws-drive
 npx skills add https://github.com/googleworkspace/cli/tree/main/skills/gws-gmail
 ```


### PR DESCRIPTION
## Summary

The selective skill installation example was missing `gws-shared`, which is a required dependency for all service skills. Updated the docs to show `gws-shared` must be installed first.

Fixes #672

## Checklist
- [x] Documentation only — no code changes
- [x] Changeset file added (patch bump)