### PR TITLE
fix(windows): force UTF-8 console codepage to prevent non-ASCII mojibake

### DIFF
--- a/.changeset/fix-windows-utf8-console.md
+++ b/.changeset/fix-windows-utf8-console.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Force UTF-8 console output on Windows to prevent CP-1252 mojibake of non-ASCII characters

--- a/crates/google-workspace-cli/src/main.rs
+++ b/crates/google-workspace-cli/src/main.rs
@@ -50,6 +50,17 @@ async fn main() {
     // Load .env file if present (silently ignored if missing)
     let _ = dotenvy::dotenv();
 
+    // Windows: force UTF-8 console output to prevent CP-1252 mojibake of non-ASCII characters
+    #[cfg(target_os = "windows")]
+    {
+        extern "system" {
+            fn SetConsoleOutputCP(wCodePageID: u32) -> i32;
+        }
+        unsafe {
+            SetConsoleOutputCP(65001);
+        }
+    }
+
     // Initialize structured logging (no-op if env vars are unset)
     logging::init_logging();
 


### PR DESCRIPTION
## Summary

On Windows, the default console codepage is CP-1252 (or the system OEM codepage), which mangles non-ASCII characters (e.g. accented names, CJK characters) in API responses.

This change calls `SetConsoleOutputCP(65001)` at startup when running on Windows, forcing the console to interpret output as UTF-8.

Fixes #742

## Checklist
- [x] `cargo fmt --all` passed
- [x] `cargo clippy -- -D warnings` passed
- [x] `cargo test` passed
- [x] Changeset file added (patch bump)
- [x] No new dependencies — uses `extern "system"` FFI