### PR TITLE
fix(services): support api:version syntax for unlisted Discovery APIs

### DIFF
--- a/.changeset/fix-api-version-syntax.md
+++ b/.changeset/fix-api-version-syntax.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Fix `<api>:<version>` syntax so unlisted Discovery APIs can be called directly

--- a/crates/google-workspace-cli/src/main.rs
+++ b/crates/google-workspace-cli/src/main.rs
@@ -340,8 +340,16 @@ pub fn parse_service_and_version(
         }
     }
 
-    let (api_name, default_version) = services::resolve_service(service_arg)?;
-    let version = version_override.unwrap_or(default_version);
+    let (api_name, version) = match services::resolve_service(service_arg) {
+        Ok((name, default_ver)) => (name, version_override.unwrap_or(default_ver)),
+        Err(e) => {
+            if let Some(ver) = version_override {
+                (service_arg.to_string(), ver)
+            } else {
+                return Err(e);
+            }
+        }
+    };
     Ok((api_name, version))
 }
 
@@ -734,5 +742,18 @@ mod tests {
     fn test_select_scope_empty() {
         let scopes: Vec<String> = vec![];
         assert_eq!(select_scope(&scopes), None);
+    }
+
+    #[test]
+    fn test_parse_service_and_version_unlisted_with_colon() {
+        // admob is not in the known services list, but admob:v1 should work
+        let args = vec![
+            "gws".to_string(),
+            "admob:v1".to_string(),
+            "accounts".to_string(),
+            "list".to_string(),
+        ];
+        let result = parse_service_and_version(&args, "admob:v1");
+        assert_eq!(result.unwrap(), ("admob".to_string(), "v1".to_string()));
     }
 }

--- a/crates/google-workspace-cli/src/main.rs
+++ b/crates/google-workspace-cli/src/main.rs
@@ -325,10 +325,12 @@ pub fn parse_service_and_version(
     let mut service_arg = first_arg;
     let mut version_override: Option<String> = None;
 
-    // Check for --api-version flag anywhere in args
+    // Check for --api-version flag anywhere in args (space-separated or = form)
     for i in 0..args.len() {
         if args[i] == "--api-version" && i + 1 < args.len() {
             version_override = Some(args[i + 1].clone());
+        } else if let Some(ver) = args[i].strip_prefix("--api-version=") {
+            version_override = Some(ver.to_string());
         }
     }
 
@@ -754,6 +756,20 @@ mod tests {
             "list".to_string(),
         ];
         let result = parse_service_and_version(&args, "admob:v1");
+        assert_eq!(result.unwrap(), ("admob".to_string(), "v1".to_string()));
+    }
+
+    #[test]
+    fn test_parse_service_and_version_unlisted_with_equals_flag() {
+        // admob is not in the known services list; --api-version=v1 (equals form) should work
+        let args = vec![
+            "gws".to_string(),
+            "admob".to_string(),
+            "--api-version=v1".to_string(),
+            "accounts".to_string(),
+            "list".to_string(),
+        ];
+        let result = parse_service_and_version(&args, "admob");
         assert_eq!(result.unwrap(), ("admob".to_string(), "v1".to_string()));
     }
 }

--- a/crates/google-workspace-cli/src/main.rs
+++ b/crates/google-workspace-cli/src/main.rs
@@ -346,7 +346,18 @@ pub fn parse_service_and_version(
         Ok((name, default_ver)) => (name, version_override.unwrap_or(default_ver)),
         Err(e) => {
             if let Some(ver) = version_override {
-                (service_arg.to_string(), ver)
+                let is_valid = |s: &str| {
+                    !s.is_empty()
+                        && s.chars()
+                            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
+                };
+                if is_valid(service_arg) && is_valid(&ver) {
+                    (service_arg.to_string(), ver)
+                } else {
+                    return Err(GwsError::Validation(
+                        "Invalid service name or version: only alphanumeric characters, underscores, hyphens, and dots are allowed.".to_string()
+                    ));
+                }
             } else {
                 return Err(e);
             }
@@ -771,5 +782,33 @@ mod tests {
         ];
         let result = parse_service_and_version(&args, "admob");
         assert_eq!(result.unwrap(), ("admob".to_string(), "v1".to_string()));
+    }
+
+    #[test]
+    fn test_parse_service_and_version_rejects_path_traversal_in_service() {
+        let args = vec![
+            "gws".to_string(),
+            "../evil:v1".to_string(),
+        ];
+        let result = parse_service_and_version(&args, "../evil:v1");
+        assert!(result.is_err(), "path traversal in service name must be rejected");
+    }
+
+    #[test]
+    fn test_parse_service_and_version_rejects_path_traversal_in_version() {
+        let args = vec![
+            "gws".to_string(),
+            "admob".to_string(),
+            "--api-version=../evil".to_string(),
+        ];
+        let result = parse_service_and_version(&args, "admob");
+        assert!(result.is_err(), "path traversal in version must be rejected");
+    }
+
+    #[test]
+    fn test_parse_service_and_version_rejects_special_chars_in_service() {
+        let args = vec!["gws".to_string(), "svc?foo:v1".to_string()];
+        let result = parse_service_and_version(&args, "svc?foo:v1");
+        assert!(result.is_err(), "special chars in service name must be rejected");
     }
 }

--- a/crates/google-workspace-cli/src/main.rs
+++ b/crates/google-workspace-cli/src/main.rs
@@ -342,16 +342,25 @@ pub fn parse_service_and_version(
         }
     }
 
+    let is_valid_api_token = |s: &str| {
+        !s.is_empty()
+            && s.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
+    };
+
     let (api_name, version) = match services::resolve_service(service_arg) {
-        Ok((name, default_ver)) => (name, version_override.unwrap_or(default_ver)),
+        Ok((name, default_ver)) => {
+            let ver = version_override.unwrap_or(default_ver);
+            if !is_valid_api_token(&ver) {
+                return Err(GwsError::Validation(
+                    "Invalid version override: only alphanumeric characters, underscores, hyphens, and dots are allowed.".to_string()
+                ));
+            }
+            (name, ver)
+        }
         Err(e) => {
             if let Some(ver) = version_override {
-                let is_valid = |s: &str| {
-                    !s.is_empty()
-                        && s.chars()
-                            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
-                };
-                if is_valid(service_arg) && is_valid(&ver) {
+                if is_valid_api_token(service_arg) && is_valid_api_token(&ver) {
                     (service_arg.to_string(), ver)
                 } else {
                     return Err(GwsError::Validation(
@@ -810,5 +819,20 @@ mod tests {
         let args = vec!["gws".to_string(), "svc?foo:v1".to_string()];
         let result = parse_service_and_version(&args, "svc?foo:v1");
         assert!(result.is_err(), "special chars in service name must be rejected");
+    }
+
+    #[test]
+    fn test_parse_service_and_version_rejects_malicious_version_override_for_listed_service() {
+        // drive IS a known listed service; a malicious version override must still be rejected
+        let args = vec![
+            "gws".to_string(),
+            "drive".to_string(),
+            "--api-version=../evil".to_string(),
+        ];
+        let result = parse_service_and_version(&args, "drive");
+        assert!(
+            result.is_err(),
+            "path traversal in version_override must be rejected even for listed services"
+        );
     }
 }


### PR DESCRIPTION
## Summary

When a user passes `gws admob:v1 ...`, `parse_service_and_version` now falls through to use the raw API name and version rather than returning an error for unknown service aliases. The original error is still returned when no version override is present.

Fixes #670

## Changes

- `crates/google-workspace-cli/src/main.rs`: when `resolve_service` fails but a version override is present, use the raw service arg as the API name
- Added regression test in the `#[cfg(test)]` block covering the `admob:v1` unlisted API case

## Checklist
- [x] `cargo fmt --all` passed (CI)
- [x] `cargo clippy -- -D warnings` passed (CI)
- [x] `cargo test` passed (CI)
- [x] Changeset file added (patch bump)