### PR TITLE
fix(formatter): exit non-zero on JSON serialization failure instead of silent empty output

### DIFF
--- a/.changeset/fix-serialization-error-exit.md
+++ b/.changeset/fix-serialization-error-exit.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Exit non-zero with a clear error message when JSON serialization fails instead of printing empty stdout

--- a/crates/google-workspace-cli/src/executor.rs
+++ b/crates/google-workspace-cli/src/executor.rs
@@ -303,11 +303,13 @@ async fn handle_json_response(
             println!(
                 "{}",
                 crate::formatter::format_value_paginated(&json_val, output_format, is_first_page)
+                    .map_err(|e| GwsError::Other(anyhow::Error::from(e)))?
             );
         } else {
             println!(
                 "{}",
                 crate::formatter::format_value(&json_val, output_format)
+                    .map_err(|e| GwsError::Other(anyhow::Error::from(e)))?
             );
         }
 
@@ -379,7 +381,11 @@ async fn handle_binary_response(
         return Ok(Some(result));
     }
 
-    println!("{}", crate::formatter::format_value(&result, output_format));
+    println!(
+        "{}",
+        crate::formatter::format_value(&result, output_format)
+            .map_err(|e| GwsError::Other(anyhow::Error::from(e)))?
+    );
 
     Ok(None)
 }
@@ -428,6 +434,7 @@ pub async fn execute_method(
         println!(
             "{}",
             crate::formatter::format_value(&dry_run_info, output_format)
+                .map_err(|e| GwsError::Other(anyhow::Error::from(e)))?
         );
         return Ok(None);
     }

--- a/crates/google-workspace-cli/src/formatter.rs
+++ b/crates/google-workspace-cli/src/formatter.rs
@@ -60,7 +60,13 @@ impl OutputFormat {
 /// Format a JSON value according to the specified output format.
 pub fn format_value(value: &Value, format: &OutputFormat) -> String {
     match format {
-        OutputFormat::Json => serde_json::to_string_pretty(value).unwrap_or_default(),
+        OutputFormat::Json => match serde_json::to_string_pretty(value) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("error: failed to serialize response to JSON: {e}");
+                std::process::exit(1);
+            }
+        },
         OutputFormat::Table => format_table(value),
         OutputFormat::Yaml => format_yaml(value),
         OutputFormat::Csv => format_csv(value),
@@ -78,7 +84,13 @@ pub fn format_value(value: &Value, format: &OutputFormat) -> String {
 /// combined stream is a valid YAML multi-document file.
 pub fn format_value_paginated(value: &Value, format: &OutputFormat, is_first_page: bool) -> String {
     match format {
-        OutputFormat::Json => serde_json::to_string(value).unwrap_or_default(),
+        OutputFormat::Json => match serde_json::to_string(value) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("error: failed to serialize response to JSON: {e}");
+                std::process::exit(1);
+            }
+        },
         OutputFormat::Csv => format_csv_page(value, is_first_page),
         OutputFormat::Table => format_table_page(value, is_first_page),
         // Prefix every page with a YAML document separator so that the
@@ -472,6 +484,13 @@ mod tests {
         let output = format_value(&val, &OutputFormat::Json);
         assert!(output.contains("\"name\""));
         assert!(output.contains("\"test\""));
+    }
+
+    #[test]
+    fn test_format_value_json_non_empty() {
+        let val = json!({"key": "value"});
+        let result = format_value(&val, &OutputFormat::Json);
+        assert!(!result.is_empty());
     }
 
     #[test]

--- a/crates/google-workspace-cli/src/formatter.rs
+++ b/crates/google-workspace-cli/src/formatter.rs
@@ -152,7 +152,7 @@ fn format_table_page(value: &Value, emit_header: bool) -> String {
     } else if let Value::Array(arr) = value {
         format_array_as_table(arr, emit_header)
     } else if let Value::Object(obj) = value {
-        // Single object: key/value table â€” flatten nested objects first
+        // Single object: key/value table — flatten nested objects first
         let mut output = String::new();
         let flat = flatten_object(obj, "");
         let max_key_len = flat.iter().map(|(k, _)| k.len()).max().unwrap_or(0);
@@ -245,11 +245,11 @@ fn format_array_as_table(arr: &[Value], emit_header: bool) -> String {
         let _ = writeln!(output, "{}", header.join("  "));
 
         // Separator
-        let sep: Vec<String> = widths.iter().map(|w| "â”€".repeat(*w)).collect();
+        let sep: Vec<String> = widths.iter().map(|w| "─".repeat(*w)).collect();
         let _ = writeln!(output, "{}", sep.join("  "));
     }
 
-    // Rows â€” truncate by char count to avoid panicking on multi-byte UTF-8.
+    // Rows — truncate by char count to avoid panicking on multi-byte UTF-8.
     for row in &rows {
         let cells: Vec<String> = row
             .iter()
@@ -259,7 +259,7 @@ fn format_array_as_table(arr: &[Value], emit_header: bool) -> String {
                 let truncated = if char_len > widths[i] {
                     // Safe char-boundary slice: take widths[i]-1 chars, then append ellipsis.
                     let truncated_str: String = c.chars().take(widths[i] - 1).collect();
-                    format!("{truncated_str}â€¦")
+                    format!("{truncated_str}…")
                 } else {
                     c.clone()
                 };
@@ -352,7 +352,7 @@ fn format_csv_page(value: &Value, emit_header: bool) -> String {
     } else if let Value::Array(arr) = value {
         arr.as_slice()
     } else {
-        // Single value â€” just output it
+        // Single value — just output it
         return value_to_cell(value);
     };
 
@@ -499,7 +499,7 @@ mod tests {
         assert!(output.contains("hello.txt"));
         assert!(output.contains("world.txt"));
         // Check separator line
-        assert!(output.contains("â”€â”€"));
+        assert!(output.contains("──"));
     }
 
     #[test]
@@ -563,7 +563,7 @@ mod tests {
     fn test_format_table_multibyte_truncation_does_not_panic() {
         // Column width cap is 60 chars, so a long string with multi-byte chars
         // must be safely truncated without a byte-boundary panic.
-        let long_emoji = "ðŸ˜€".repeat(70); // each emoji is 4 bytes
+        let long_emoji = "😀".repeat(70); // each emoji is 4 bytes
         let val = json!([{"col": long_emoji}]);
         // Should not panic
         let output = format_value(&val, &OutputFormat::Table).unwrap();
@@ -573,7 +573,7 @@ mod tests {
     #[test]
     fn test_format_table_multibyte_exact_boundary() {
         // Multi-byte chars at various positions must not panic or produce garbled output.
-        let val = json!([{"name": "cafÃ© rÃ©sumÃ© naÃ¯ve"}]);
+        let val = json!([{"name": "café résumé naïve"}]);
         let output = format_value(&val, &OutputFormat::Table).unwrap();
         assert!(output.contains("name"), "column must appear:\n{output}");
     }
@@ -611,7 +611,7 @@ mod tests {
 
     #[test]
     fn test_format_csv_flat_scalars() {
-        // Flat array of non-object, non-array values â†’ one value per line
+        // Flat array of non-object, non-array values → one value per line
         let val = json!(["apple", "banana", "cherry"]);
         let output = format_value(&val, &OutputFormat::Csv).unwrap();
         let lines: Vec<&str> = output.lines().collect();
@@ -756,7 +756,7 @@ mod tests {
             output.contains("id"),
             "table header must appear on first page"
         );
-        assert!(output.contains("â”€â”€"), "separator must appear on first page");
+        assert!(output.contains("──"), "separator must appear on first page");
     }
 
     #[test]
@@ -769,7 +769,7 @@ mod tests {
         let output = format_value_paginated(&val, &OutputFormat::Table, false).unwrap();
         assert!(output.contains("bar"), "data row must be present");
         assert!(
-            !output.contains("â”€â”€"),
+            !output.contains("──"),
             "separator must be absent on continuation pages"
         );
     }

--- a/crates/google-workspace-cli/src/formatter.rs
+++ b/crates/google-workspace-cli/src/formatter.rs
@@ -58,18 +58,12 @@ impl OutputFormat {
 }
 
 /// Format a JSON value according to the specified output format.
-pub fn format_value(value: &Value, format: &OutputFormat) -> String {
+pub fn format_value(value: &Value, format: &OutputFormat) -> Result<String, serde_json::Error> {
     match format {
-        OutputFormat::Json => match serde_json::to_string_pretty(value) {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("{}", crate::output::sanitize_for_terminal(&format!("error: failed to serialize response to JSON: {e}")));
-                std::process::exit(1);
-            }
-        },
-        OutputFormat::Table => format_table(value),
-        OutputFormat::Yaml => format_yaml(value),
-        OutputFormat::Csv => format_csv(value),
+        OutputFormat::Json => serde_json::to_string_pretty(value),
+        OutputFormat::Table => Ok(format_table(value)),
+        OutputFormat::Yaml => Ok(format_yaml(value)),
+        OutputFormat::Csv => Ok(format_csv(value)),
     }
 }
 
@@ -82,20 +76,18 @@ pub fn format_value(value: &Value, format: &OutputFormat) -> String {
 /// For JSON the output is compact (one JSON object per line / NDJSON).
 /// For YAML each page is prefixed with a `---` document separator so the
 /// combined stream is a valid YAML multi-document file.
-pub fn format_value_paginated(value: &Value, format: &OutputFormat, is_first_page: bool) -> String {
+pub fn format_value_paginated(
+    value: &Value,
+    format: &OutputFormat,
+    is_first_page: bool,
+) -> Result<String, serde_json::Error> {
     match format {
-        OutputFormat::Json => match serde_json::to_string(value) {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("{}", crate::output::sanitize_for_terminal(&format!("error: failed to serialize response to JSON: {e}")));
-                std::process::exit(1);
-            }
-        },
-        OutputFormat::Csv => format_csv_page(value, is_first_page),
-        OutputFormat::Table => format_table_page(value, is_first_page),
+        OutputFormat::Json => serde_json::to_string(value),
+        OutputFormat::Csv => Ok(format_csv_page(value, is_first_page)),
+        OutputFormat::Table => Ok(format_table_page(value, is_first_page)),
         // Prefix every page with a YAML document separator so that the
         // concatenated stream is parseable as a multi-document YAML file.
-        OutputFormat::Yaml => format!("---\n{}", format_yaml(value)),
+        OutputFormat::Yaml => Ok(format!("---\n{}", format_yaml(value))),
     }
 }
 
@@ -160,7 +152,7 @@ fn format_table_page(value: &Value, emit_header: bool) -> String {
     } else if let Value::Array(arr) = value {
         format_array_as_table(arr, emit_header)
     } else if let Value::Object(obj) = value {
-        // Single object: key/value table — flatten nested objects first
+        // Single object: key/value table â€” flatten nested objects first
         let mut output = String::new();
         let flat = flatten_object(obj, "");
         let max_key_len = flat.iter().map(|(k, _)| k.len()).max().unwrap_or(0);
@@ -253,11 +245,11 @@ fn format_array_as_table(arr: &[Value], emit_header: bool) -> String {
         let _ = writeln!(output, "{}", header.join("  "));
 
         // Separator
-        let sep: Vec<String> = widths.iter().map(|w| "─".repeat(*w)).collect();
+        let sep: Vec<String> = widths.iter().map(|w| "â”€".repeat(*w)).collect();
         let _ = writeln!(output, "{}", sep.join("  "));
     }
 
-    // Rows — truncate by char count to avoid panicking on multi-byte UTF-8.
+    // Rows â€” truncate by char count to avoid panicking on multi-byte UTF-8.
     for row in &rows {
         let cells: Vec<String> = row
             .iter()
@@ -267,7 +259,7 @@ fn format_array_as_table(arr: &[Value], emit_header: bool) -> String {
                 let truncated = if char_len > widths[i] {
                     // Safe char-boundary slice: take widths[i]-1 chars, then append ellipsis.
                     let truncated_str: String = c.chars().take(widths[i] - 1).collect();
-                    format!("{truncated_str}…")
+                    format!("{truncated_str}â€¦")
                 } else {
                     c.clone()
                 };
@@ -360,7 +352,7 @@ fn format_csv_page(value: &Value, emit_header: bool) -> String {
     } else if let Value::Array(arr) = value {
         arr.as_slice()
     } else {
-        // Single value — just output it
+        // Single value â€” just output it
         return value_to_cell(value);
     };
 
@@ -481,7 +473,7 @@ mod tests {
     #[test]
     fn test_format_json() {
         let val = json!({"name": "test"});
-        let output = format_value(&val, &OutputFormat::Json);
+        let output = format_value(&val, &OutputFormat::Json).unwrap();
         assert!(output.contains("\"name\""));
         assert!(output.contains("\"test\""));
     }
@@ -489,7 +481,7 @@ mod tests {
     #[test]
     fn test_format_value_json_non_empty() {
         let val = json!({"key": "value"});
-        let result = format_value(&val, &OutputFormat::Json);
+        let result = format_value(&val, &OutputFormat::Json).unwrap();
         assert!(!result.is_empty());
     }
 
@@ -501,19 +493,19 @@ mod tests {
                 {"id": "2", "name": "world.txt"}
             ]
         });
-        let output = format_value(&val, &OutputFormat::Table);
+        let output = format_value(&val, &OutputFormat::Table).unwrap();
         assert!(output.contains("id"));
         assert!(output.contains("name"));
         assert!(output.contains("hello.txt"));
         assert!(output.contains("world.txt"));
         // Check separator line
-        assert!(output.contains("──"));
+        assert!(output.contains("â”€â”€"));
     }
 
     #[test]
     fn test_format_table_single_object() {
         let val = json!({"id": "abc", "name": "test"});
-        let output = format_value(&val, &OutputFormat::Table);
+        let output = format_value(&val, &OutputFormat::Table).unwrap();
         assert!(output.contains("id"));
         assert!(output.contains("abc"));
     }
@@ -531,7 +523,7 @@ mod tests {
                 "usage": "500"
             }
         });
-        let output = format_value(&val, &OutputFormat::Table);
+        let output = format_value(&val, &OutputFormat::Table).unwrap();
         // Should contain dot-notation keys
         assert!(
             output.contains("user.displayName"),
@@ -558,7 +550,7 @@ mod tests {
             {"id": "1", "owner": {"name": "Alice"}},
             {"id": "2", "owner": {"name": "Bob"}}
         ]);
-        let output = format_value(&val, &OutputFormat::Table);
+        let output = format_value(&val, &OutputFormat::Table).unwrap();
         assert!(
             output.contains("owner.name"),
             "expected flattened column:\n{output}"
@@ -571,18 +563,18 @@ mod tests {
     fn test_format_table_multibyte_truncation_does_not_panic() {
         // Column width cap is 60 chars, so a long string with multi-byte chars
         // must be safely truncated without a byte-boundary panic.
-        let long_emoji = "😀".repeat(70); // each emoji is 4 bytes
+        let long_emoji = "ðŸ˜€".repeat(70); // each emoji is 4 bytes
         let val = json!([{"col": long_emoji}]);
         // Should not panic
-        let output = format_value(&val, &OutputFormat::Table);
+        let output = format_value(&val, &OutputFormat::Table).unwrap();
         assert!(output.contains("col"), "column name must appear:\n{output}");
     }
 
     #[test]
     fn test_format_table_multibyte_exact_boundary() {
         // Multi-byte chars at various positions must not panic or produce garbled output.
-        let val = json!([{"name": "café résumé naïve"}]);
-        let output = format_value(&val, &OutputFormat::Table);
+        let val = json!([{"name": "cafÃ© rÃ©sumÃ© naÃ¯ve"}]);
+        let output = format_value(&val, &OutputFormat::Table).unwrap();
         assert!(output.contains("name"), "column must appear:\n{output}");
     }
 
@@ -594,7 +586,7 @@ mod tests {
                 {"id": "2", "name": "world"}
             ]
         });
-        let output = format_value(&val, &OutputFormat::Csv);
+        let output = format_value(&val, &OutputFormat::Csv).unwrap();
         assert!(output.contains("id,name"));
         assert!(output.contains("1,hello"));
         assert!(output.contains("2,world"));
@@ -610,7 +602,7 @@ mod tests {
                 ["Andrew", "Male", "1. Freshman"]
             ]
         });
-        let output = format_value(&val, &OutputFormat::Csv);
+        let output = format_value(&val, &OutputFormat::Csv).unwrap();
         let lines: Vec<&str> = output.lines().collect();
         assert_eq!(lines[0], "Student Name,Gender,Class Level");
         assert_eq!(lines[1], "Alexandra,Female,4. Senior");
@@ -619,9 +611,9 @@ mod tests {
 
     #[test]
     fn test_format_csv_flat_scalars() {
-        // Flat array of non-object, non-array values → one value per line
+        // Flat array of non-object, non-array values â†’ one value per line
         let val = json!(["apple", "banana", "cherry"]);
-        let output = format_value(&val, &OutputFormat::Csv);
+        let output = format_value(&val, &OutputFormat::Csv).unwrap();
         let lines: Vec<&str> = output.lines().collect();
         assert_eq!(lines.len(), 3);
         assert_eq!(lines[0], "apple");
@@ -633,7 +625,7 @@ mod tests {
     fn test_format_csv_flat_scalars_with_escaping() {
         // Scalars that contain commas/quotes must be CSV-escaped
         let val = json!(["plain", "has,comma", "has\"quote"]);
-        let output = format_value(&val, &OutputFormat::Csv);
+        let output = format_value(&val, &OutputFormat::Csv).unwrap();
         let lines: Vec<&str> = output.lines().collect();
         assert_eq!(lines.len(), 3);
         assert_eq!(lines[0], "plain");
@@ -651,7 +643,7 @@ mod tests {
     #[test]
     fn test_format_yaml() {
         let val = json!({"name": "test", "count": 42});
-        let output = format_value(&val, &OutputFormat::Yaml);
+        let output = format_value(&val, &OutputFormat::Yaml).unwrap();
         assert!(output.contains("name: \"test\""));
         assert!(output.contains("count: 42"));
     }
@@ -660,7 +652,7 @@ mod tests {
     fn test_format_table_empty_array() {
         let val = json!({"files": []});
         // No items to extract, falls back to single-object table
-        let output = format_value(&val, &OutputFormat::Table);
+        let output = format_value(&val, &OutputFormat::Table).unwrap();
         assert!(output.contains("files"));
     }
 
@@ -685,7 +677,7 @@ mod tests {
         // `drive#file` contains `#` which is a YAML comment marker; the
         // serialiser must quote it rather than emit a block scalar.
         let val = json!({"kind": "drive#file", "id": "123"});
-        let output = format_value(&val, &OutputFormat::Yaml);
+        let output = format_value(&val, &OutputFormat::Yaml).unwrap();
         // Must be a double-quoted string, not a block scalar (`|`).
         assert!(
             output.contains("kind: \"drive#file\""),
@@ -700,7 +692,7 @@ mod tests {
     #[test]
     fn test_format_yaml_colon_in_string_is_quoted() {
         let val = json!({"url": "https://example.com/path"});
-        let output = format_value(&val, &OutputFormat::Yaml);
+        let output = format_value(&val, &OutputFormat::Yaml).unwrap();
         assert!(
             output.contains("url: \"https://example.com/path\""),
             "expected double-quoted url, got:\n{output}"
@@ -711,7 +703,7 @@ mod tests {
     #[test]
     fn test_format_yaml_multiline_still_uses_block() {
         let val = json!({"body": "line one\nline two"});
-        let output = format_value(&val, &OutputFormat::Yaml);
+        let output = format_value(&val, &OutputFormat::Yaml).unwrap();
         // Multi-line content should still use block scalar.
         assert!(
             output.contains("body: |"),
@@ -729,7 +721,7 @@ mod tests {
                 {"id": "2", "name": "b.txt"}
             ]
         });
-        let output = format_value_paginated(&val, &OutputFormat::Csv, true);
+        let output = format_value_paginated(&val, &OutputFormat::Csv, true).unwrap();
         let lines: Vec<&str> = output.lines().collect();
         assert_eq!(lines[0], "id,name", "first page must start with header");
         assert_eq!(lines[1], "1,a.txt");
@@ -742,7 +734,7 @@ mod tests {
                 {"id": "3", "name": "c.txt"}
             ]
         });
-        let output = format_value_paginated(&val, &OutputFormat::Csv, false);
+        let output = format_value_paginated(&val, &OutputFormat::Csv, false).unwrap();
         let lines: Vec<&str> = output.lines().collect();
         // The first (and only) line must be a data row, not the header.
         assert_eq!(lines[0], "3,c.txt", "continuation page must have no header");
@@ -759,12 +751,12 @@ mod tests {
                 {"id": "1", "name": "foo"}
             ]
         });
-        let output = format_value_paginated(&val, &OutputFormat::Table, true);
+        let output = format_value_paginated(&val, &OutputFormat::Table, true).unwrap();
         assert!(
             output.contains("id"),
             "table header must appear on first page"
         );
-        assert!(output.contains("──"), "separator must appear on first page");
+        assert!(output.contains("â”€â”€"), "separator must appear on first page");
     }
 
     #[test]
@@ -774,10 +766,10 @@ mod tests {
                 {"id": "2", "name": "bar"}
             ]
         });
-        let output = format_value_paginated(&val, &OutputFormat::Table, false);
+        let output = format_value_paginated(&val, &OutputFormat::Table, false).unwrap();
         assert!(output.contains("bar"), "data row must be present");
         assert!(
-            !output.contains("──"),
+            !output.contains("â”€â”€"),
             "separator must be absent on continuation pages"
         );
     }
@@ -785,8 +777,8 @@ mod tests {
     #[test]
     fn test_format_value_paginated_yaml_has_document_separator() {
         let val = json!({"files": [{"id": "1", "name": "foo"}]});
-        let first = format_value_paginated(&val, &OutputFormat::Yaml, true);
-        let second = format_value_paginated(&val, &OutputFormat::Yaml, false);
+        let first = format_value_paginated(&val, &OutputFormat::Yaml, true).unwrap();
+        let second = format_value_paginated(&val, &OutputFormat::Yaml, false).unwrap();
         assert!(
             first.starts_with("---\n"),
             "first YAML page must start with ---"

--- a/crates/google-workspace-cli/src/formatter.rs
+++ b/crates/google-workspace-cli/src/formatter.rs
@@ -63,7 +63,7 @@ pub fn format_value(value: &Value, format: &OutputFormat) -> String {
         OutputFormat::Json => match serde_json::to_string_pretty(value) {
             Ok(s) => s,
             Err(e) => {
-                eprintln!("error: failed to serialize response to JSON: {e}");
+                eprintln!("{}", crate::output::sanitize_for_terminal(&format!("error: failed to serialize response to JSON: {e}")));
                 std::process::exit(1);
             }
         },
@@ -87,7 +87,7 @@ pub fn format_value_paginated(value: &Value, format: &OutputFormat, is_first_pag
         OutputFormat::Json => match serde_json::to_string(value) {
             Ok(s) => s,
             Err(e) => {
-                eprintln!("error: failed to serialize response to JSON: {e}");
+                eprintln!("{}", crate::output::sanitize_for_terminal(&format!("error: failed to serialize response to JSON: {e}")));
                 std::process::exit(1);
             }
         },

--- a/crates/google-workspace-cli/src/helpers/calendar.rs
+++ b/crates/google-workspace-cli/src/helpers/calendar.rs
@@ -415,6 +415,7 @@ async fn handle_agenda(matches: &ArgMatches) -> Result<(), GwsError> {
     println!(
         "{}",
         crate::formatter::format_value(&output, &output_format)
+            .map_err(|e| GwsError::Other(anyhow::Error::from(e)))?
     );
     Ok(())
 }

--- a/crates/google-workspace-cli/src/helpers/gmail/triage.rs
+++ b/crates/google-workspace-cli/src/helpers/gmail/triage.rs
@@ -173,6 +173,7 @@ pub async fn handle_triage(matches: &ArgMatches) -> Result<(), GwsError> {
     println!(
         "{}",
         crate::formatter::format_value(&output, &output_format)
+            .map_err(|e| GwsError::Other(anyhow::Error::from(e)))?
     );
 
     Ok(())

--- a/crates/google-workspace-cli/src/helpers/workflows.rs
+++ b/crates/google-workspace-cli/src/helpers/workflows.rs
@@ -259,12 +259,17 @@ async fn get_json(
         .map_err(|e| GwsError::Other(anyhow::anyhow!("JSON parse failed: {e}")))
 }
 
-fn format_and_print(value: &Value, matches: &ArgMatches) {
+fn format_and_print(value: &Value, matches: &ArgMatches) -> Result<(), GwsError> {
     let fmt = matches
         .get_one::<String>("format")
         .map(|s| crate::formatter::OutputFormat::from_str(s))
         .unwrap_or_default();
-    println!("{}", crate::formatter::format_value(value, &fmt));
+    println!(
+        "{}",
+        crate::formatter::format_value(value, &fmt)
+            .map_err(|e| GwsError::Other(anyhow::Error::from(e)))?
+    );
+    Ok(())
 }
 
 async fn handle_standup_report(matches: &ArgMatches) -> Result<(), GwsError> {
@@ -361,7 +366,7 @@ async fn handle_standup_report(matches: &ArgMatches) -> Result<(), GwsError> {
         "date": now_in_tz.format("%Y-%m-%d").to_string(),
     });
 
-    format_and_print(&output, matches);
+    format_and_print(&output, matches)?;
     Ok(())
 }
 
@@ -405,7 +410,7 @@ async fn handle_meeting_prep(matches: &ArgMatches) -> Result<(), GwsError> {
 
     if items.is_empty() {
         let output = json!({ "message": "No upcoming meetings found." });
-        format_and_print(&output, matches);
+        format_and_print(&output, matches)?;
         return Ok(());
     }
 
@@ -438,7 +443,7 @@ async fn handle_meeting_prep(matches: &ArgMatches) -> Result<(), GwsError> {
         "attendeeCount": attendee_list.len(),
     });
 
-    format_and_print(&output, matches);
+    format_and_print(&output, matches)?;
     Ok(())
 }
 
@@ -528,7 +533,7 @@ async fn handle_email_to_task(matches: &ArgMatches) -> Result<(), GwsError> {
         "sourceMessageId": message_id,
     });
 
-    format_and_print(&output, matches);
+    format_and_print(&output, matches)?;
     Ok(())
 }
 
@@ -613,7 +618,7 @@ async fn handle_weekly_digest(matches: &ArgMatches) -> Result<(), GwsError> {
         "periodEnd": time_max,
     });
 
-    format_and_print(&output, matches);
+    format_and_print(&output, matches)?;
     Ok(())
 }
 
@@ -686,7 +691,7 @@ async fn handle_file_announce(matches: &ArgMatches) -> Result<(), GwsError> {
         "space": space,
     });
 
-    format_and_print(&output, matches);
+    format_and_print(&output, matches)?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

When `serde_json::to_string_pretty` failed (e.g. on values containing NaN/Infinity), `format_value` returned an empty string via `unwrap_or_default()`. The CLI then printed nothing and exited 0, silently swallowing the API response.

This change replaces the silent fallback with an explicit stderr error message and a non-zero exit code. The same fix is applied to `format_value_paginated` which had the identical issue.

Fixes #740

## Changes

- `format_value`: replaced `unwrap_or_default()` with an explicit `match` that prints `error: failed to serialize response to JSON: {e}` to stderr and exits with code 1
- `format_value_paginated`: same fix for the compact JSON path
- Added `test_format_value_json_non_empty` test to assert valid values always produce non-empty output

## Checklist
- [x] `cargo fmt --all` passed
- [x] `cargo clippy -- -D warnings` passed
- [x] `cargo test` passed
- [x] Changeset file added (patch bump)