### PR TITLE
fix(error): use compact JSON for error output to preserve NDJSON streams

### DIFF
--- a/.changeset/fix-680-compact-error-json.md
+++ b/.changeset/fix-680-compact-error-json.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+fix(error): use compact JSON for error output to preserve NDJSON stream compatibility

--- a/crates/google-workspace-cli/src/error.rs
+++ b/crates/google-workspace-cli/src/error.rs
@@ -67,7 +67,7 @@ pub fn print_error_json(err: &GwsError) {
     let json = err.to_json();
     println!(
         "{}",
-        serde_json::to_string_pretty(&json).unwrap_or_default()
+        serde_json::to_string(&json).unwrap_or_default()
     );
 
     // Print a colored summary to stderr. For accessNotConfigured errors,
@@ -149,5 +149,32 @@ mod tests {
 
         let input3 = "hello\x07bell\x08backspace";
         assert_eq!(sanitize_for_terminal(input3), "hellobellbackspace");
+    }
+
+    #[test]
+    fn test_print_error_json_is_single_line() {
+        // Verify that the JSON serialized from each error variant contains no
+        // newline characters, preserving NDJSON stream compatibility.
+        let errors = vec![
+            GwsError::Api {
+                code: 403,
+                message: "Forbidden".to_string(),
+                reason: "forbidden".to_string(),
+                enable_url: Some("https://example.com".to_string()),
+            },
+            GwsError::Auth("token expired".to_string()),
+            GwsError::Validation("bad argument".to_string()),
+            GwsError::Discovery("schema missing".to_string()),
+            GwsError::Other(anyhow::anyhow!("unexpected")),
+        ];
+
+        for err in &errors {
+            let json = err.to_json();
+            let output = serde_json::to_string(&json).unwrap_or_default();
+            assert!(
+                !output.contains('\n'),
+                "error JSON must be a single line for NDJSON compatibility, got:\n{output}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Description

`print_error_json` was using `serde_json::to_string_pretty`, which produces multi-line output. This breaks NDJSON consumers (e.g. `gmail +watch`, `events +subscribe`) that expect one JSON object per line.

Changed to `serde_json::to_string` so errors are always emitted as a single line, consistent with the NDJSON protocol.

Closes #680

## Checklist:
- [ ] My code follows the AGENTS.md guidelines (no generated `google-*` crates).
- [ ] I have run `cargo fmt --all` to format the code perfectly.
- [ ] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.