### PR TITLE
Fix dynamic help usage service paths

### DIFF
--- a/.changeset/fix-help-usage-service-path.md
+++ b/.changeset/fix-help-usage-service-path.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Include the service name in dynamic command help usage paths.

--- a/crates/google-workspace-cli/src/commands.rs
+++ b/crates/google-workspace-cli/src/commands.rs
@@ -18,11 +18,17 @@ use crate::discovery::{RestDescription, RestResource};
 
 /// Builds the full CLI command tree from a Discovery Document.
 pub fn build_cli(doc: &RestDescription) -> Command {
+    build_cli_for_service(doc, &doc.name)
+}
+
+/// Builds the full CLI command tree with the user-facing service name in help usage.
+pub fn build_cli_for_service(doc: &RestDescription, service_name: &str) -> Command {
     let about_text = doc
         .description
         .clone()
         .unwrap_or_else(|| "Google Workspace CLI".to_string());
     let mut root = Command::new("gws")
+        .bin_name(format!("gws {service_name}"))
         .about(about_text)
         .subcommand_required(true)
         .arg_required_else_help(true)
@@ -277,6 +283,35 @@ mod tests {
         assert!(
             sanitize_arg.is_some(),
             "--sanitize arg should be present on root command"
+        );
+    }
+
+    #[test]
+    fn test_help_usage_includes_service_name() {
+        let doc = make_doc();
+
+        let service_help = build_cli(&doc)
+            .try_get_matches_from(["gws", "--help"])
+            .unwrap_err();
+        assert_eq!(service_help.kind(), clap::error::ErrorKind::DisplayHelp);
+        let service_help = service_help.to_string();
+        assert!(
+            service_help.contains("Usage: gws drive [OPTIONS] <COMMAND>"),
+            "{service_help}"
+        );
+
+        let resource_help = build_cli(&doc)
+            .try_get_matches_from(["gws", "files", "--help"])
+            .unwrap_err();
+        assert_eq!(resource_help.kind(), clap::error::ErrorKind::DisplayHelp);
+        let resource_help = resource_help.to_string();
+        assert!(
+            resource_help.contains("Usage: gws drive files [OPTIONS] <COMMAND>"),
+            "{resource_help}"
+        );
+        assert!(
+            !resource_help.contains("Usage: gws files [OPTIONS] <COMMAND>"),
+            "{resource_help}"
         );
     }
 }


### PR DESCRIPTION
Fixes #839

## Summary
- Set the dynamic clap command bin name to `gws <service>` so service and resource help show the full command path.
- Add a regression test for service-level and resource-level help usage.
- Add a patch changeset for `@googleworkspace/cli`.

## Verification
RED:
- `cargo test -p google-workspace-cli commands::tests::test_help_usage_includes_service_name -- --nocapture`
  - Failed before the fix because service help rendered `Usage: gws [OPTIONS] <COMMAND>`.

GREEN:
- `cargo test -p google-workspace-cli commands::tests::test_help_usage_includes_service_name -- --nocapture` - passed, 1 test.
- `cargo test -p google-workspace-cli` - passed, 710 tests.
- `cargo fmt --check` - passed.
- `cargo clippy -p google-workspace-cli --bin gws -- -D warnings` - passed.
- `cargo run -p google-workspace-cli -- sheets --help | grep -E "^Usage:"` - `Usage: gws sheets [OPTIONS] <COMMAND>`.
- `cargo run -p google-workspace-cli -- sheets spreadsheets --help | grep -E "^Usage:"` - `Usage: gws sheets spreadsheets [OPTIONS] <COMMAND>`.
- `git diff --check` - passed.

## Not run / notes
- Full workspace `cargo test` was not run because this change is limited to the `google-workspace-cli` crate; the affected package test suite passed.
- `cargo clippy -p google-workspace-cli --all-targets -- -D warnings` was attempted, but it currently fails on existing warnings outside this change, including `credential_store.rs`, `executor.rs`, helper tests, `setup.rs`, and `main.rs`.