### PR TITLE
feat(services): add Chrome Web Store API to the service registry

### DIFF
--- a/crates/google-workspace/src/services.rs
+++ b/crates/google-workspace/src/services.rs
@@ -136,6 +136,12 @@ pub const SERVICES: &[ServiceEntry] = &[
         version: "v1",
         description: "Manage Google Apps Script projects",
     },
+    ServiceEntry {
+        aliases: &["chromewebstore"],
+        api_name: "chromewebstore",
+        version: "v1.1",
+        description: "Manage Chrome Web Store items (upload and publish extensions)",
+    },
 ];
 
 /// Resolves a service alias to (api_name, version).
@@ -173,6 +179,10 @@ mod tests {
         assert_eq!(
             resolve_service("reports").unwrap(),
             ("admin".to_string(), "reports_v1".to_string())
+        );
+        assert_eq!(
+            resolve_service("chromewebstore").unwrap(),
+            ("chromewebstore".to_string(), "v1.1".to_string())
         );
     }
 


### PR DESCRIPTION
## What

Registers the **Chrome Web Store API** (`chromewebstore`, `v1.1`) in the static service registry (`crates/google-workspace/src/services.rs`).

## Why

`chromewebstore` is a Discovery-listed Google API for managing your *own* store items — the canonical programmatic way to **upload and publish Chrome extensions / themes / apps** (the API behind tools like `chrome-webstore-upload`). It wasn't in the registry, so:

```console
$ gws chromewebstore items get --params '{"itemId":"…"}'
Unknown service 'chromewebstore'. Known services: drive, sheets, … script.
Use '<api>:<version>' syntax for unlisted APIs.
```

The suggested `<api>:<version>` escape hatch doesn't actually help here: `parse_service_and_version` splits the colon but still calls `resolve_service`, which only knows registered aliases — so the API was unreachable by any invocation.

## How

Per `AGENTS.md` ("when adding a new service, you only need to register it in `services.rs` and verify the Discovery URL pattern in `discovery.rs`"), this is a one-entry change. No `discovery.rs` change is needed: the standard `https://www.googleapis.com/discovery/v1/apis/chromewebstore/v1.1/rest` URL 404s, but the existing **`$discovery/rest` fallback** already fetches `https://chromewebstore.googleapis.com/$discovery/rest?version=v1.1` (HTTP 200) — the same path Forms/Keep/Meet use.

## Verification

```console
# unit test (added)
$ cargo test -p google-workspace services::
test services::tests::test_resolve_service_known ... ok   # now also asserts chromewebstore → v1.1

# end-to-end against the live discovery doc (no auth needed)
$ gws schema chromewebstore.items.get
{ "description": "Gets your own Chrome Web Store item.", "httpMethod": "GET",
  "path": "chromewebstore/v1.1/items/{itemId}", … }
```

Methods now exposed: `items.insert` / `items.get` / `items.update` (media upload of the `.zip`) / `items.publish`.
Scopes: `https://www.googleapis.com/auth/chromewebstore` (+ `.readonly`).

This unlocks a full publish flow, e.g.:

```console
$ gws chromewebstore items update  --itemId <ID> --upload dist.zip
$ gws chromewebstore items publish --itemId <ID>
```

`cargo fmt --check` and `cargo clippy` are clean.