### PR TITLE
docs: clarify Gmail API ID web links

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,15 @@ gws workflow +standup-report
 gws calendar +agenda --today --timezone America/New_York
 ```
 
+> **Gmail message links:** Gmail API message and thread IDs are not durable
+> Gmail web permalinks. The common `https://mail.google.com/mail/u/0/#all/<id>`
+> form depends on Gmail's loaded web app resolving an internal alias and can fail
+> from a cold browser load. If you need an API-derivable browser link, use a
+> `rfc822msgid:<Message-ID>` Gmail search URL instead; there is currently no
+> supported offline conversion from Gmail API IDs to the opaque web IDs used in
+> Gmail permalinks. See issue #858 and the inverse web-URL-to-API-ID discussion in
+> issue #790.
+
 ### Model Armor (Response Sanitization)
 
 Integrate [Google Cloud Model Armor](https://cloud.google.com/security/products/model-armor) to scan API responses for prompt injection before they reach your agent.

--- a/skills/gws-gmail-read/SKILL.md
+++ b/skills/gws-gmail-read/SKILL.md
@@ -45,6 +45,11 @@ gws gmail +read --id 18f1a2b3c4d --format json | jq '.body'
 
 - Converts HTML-only messages to plain text automatically.
 - Handles multipart/alternative and base64 decoding.
+- Gmail API IDs are not durable Gmail web permalinks. For an API-derivable
+  browser link, read the `Message-ID` header with `--headers` and use a Gmail
+  search URL like `https://mail.google.com/mail/u/0/#search/rfc822msgid:<id>`;
+  there is no supported offline conversion from API hex IDs to Gmail's opaque
+  web permalink IDs.
 
 ## See Also
 

--- a/skills/gws-gmail/SKILL.md
+++ b/skills/gws-gmail/SKILL.md
@@ -59,3 +59,22 @@ gws schema gmail.<resource>.<method>
 
 Use `gws schema` output to build your `--params` and `--json` flags.
 
+## Gmail message links
+
+Gmail API `id` and `threadId` values are not durable Gmail web permalinks. The
+common `https://mail.google.com/mail/u/0/#all/<id>` form relies on a loaded,
+signed-in Gmail web app resolving an internal alias and can fail from a cold
+browser load.
+
+If you need a browser link that can be derived from API data, read the
+`Message-ID` header and use a Gmail search URL such as:
+
+```text
+https://mail.google.com/mail/u/0/#search/rfc822msgid:<message-id@example.com>
+```
+
+That search URL is not a direct permalink, but it is the supported API-derivable
+option today. There is currently no supported offline conversion from Gmail API
+hex IDs to the opaque web IDs used in Gmail permalinks. See issue #858 and the
+inverse web-URL-to-API-ID discussion in issue #790.
+


### PR DESCRIPTION
## Summary
Fixes #858

Document that Gmail API message/thread IDs are not durable Gmail web permalinks and that `#all/<hexId>` is an unofficial alias that can fail from a cold browser load.

## Changes
- Add a README note about Gmail API IDs, opaque Gmail web permalink IDs, and the `rfc822msgid:<Message-ID>` search fallback.
- Add the same guidance to the generated `gws-gmail` skill docs.
- Add a shorter tip to `gws-gmail-read` so agents know how to derive a browser-search URL from headers.

## Test Plan
- `python3` markdown fence balance check for changed Markdown files: passed
- `cargo test`: attempted, but the environment is missing linker `cc` (`linker cc not found`), so Rust tests could not run here