### PR TITLE
docs: add Autohand Code skills setup

### DIFF
--- a/.changeset/autohand-code-skills-docs.md
+++ b/.changeset/autohand-code-skills-docs.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Document Autohand Code setup paths for bundled agent skills.

--- a/README.md
+++ b/README.md
@@ -243,6 +243,25 @@ The `gws-shared` skill includes an `install` block so OpenClaw auto-installs the
 
 </details>
 
+<details>
+<summary>Autohand Code setup</summary>
+
+Autohand Code reads skills from `~/.autohand/skills/` globally or `.autohand/skills/` in a workspace.
+
+```bash
+# Symlink all skills globally (stays in sync with repo)
+mkdir -p ~/.autohand/skills/
+ln -s $(pwd)/skills/gws-* ~/.autohand/skills/
+
+# Or install selected skills for one workspace
+mkdir -p .autohand/skills/
+cp -r skills/gws-drive skills/gws-gmail .autohand/skills/
+```
+
+Authenticate `gws` first with `gws auth setup` or `gws auth login`, then ask Autohand to use a skill by name, for example `Use gws-drive to list recent files`. Autohand also provides `autohand --skill-install` for cataloged skills, with `--project` for workspace-level installs; use the direct copy or symlink path above until these skills are listed in that catalog.
+
+</details>
+
 ## Gemini CLI Extension
 
 1. Authenticate the CLI first:


### PR DESCRIPTION
## Summary

Adds Autohand Code setup notes for the bundled Google Workspace agent skills.

The new README details show users where Autohand Code can read skills from:

- `~/.autohand/skills/` for global installs
- `.autohand/skills/` for workspace-local installs

It also keeps the wording conservative by recommending direct copy or symlink setup until these skills are available through the Autohand skill catalog.

## Changes

- Add an `Autohand Code setup` details block under the existing Agent Skills section.
- Add a changeset for the docs-only update.

## Validation

- `git diff --check`
- `cargo test`
- `cargo clippy -- -D warnings` currently fails on this local Rust 1.88.0 toolchain due to pre-existing `clippy::uninlined_format_args` warnings in `crates/google-workspace/src/client.rs` and `crates/google-workspace/src/validate.rs`. This PR only changes `README.md` and adds a changeset.
