### PR TITLE
fix(executor): skip x-goog-user-project header for OAuth auth method

### DIFF
--- a/.changeset/fix-oauth-quota-project-header.md
+++ b/.changeset/fix-oauth-quota-project-header.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Skip x-goog-user-project header for OAuth auth to fix 403 errors for non-project-member users

--- a/crates/google-workspace-cli/src/auth.rs
+++ b/crates/google-workspace-cli/src/auth.rs
@@ -126,13 +126,15 @@ fn adc_well_known_path() -> Option<PathBuf> {
     })
 }
 
-/// What kind of credential provided the token.
-#[derive(Debug, Clone, PartialEq)]
-pub enum CredentialKind {
-    /// Browser-based OAuth 2.0 user credential (from `gws auth login`)
-    UserOAuth,
-    /// Service-account key credential
+/// Tracks what authentication method was used for the request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthMethod {
+    /// OAuth2 bearer token from a user credential (`gws auth login`)
+    OAuth,
+    /// Bearer token from a service-account key
     ServiceAccount,
+    /// No authentication was provided
+    None,
 }
 
 /// Types of credentials we support
@@ -238,12 +240,12 @@ pub async fn get_token(scopes: &[&str]) -> anyhow::Result<String> {
     get_token_inner(scopes, creds, &token_cache).await
 }
 
-/// Like [`get_token`] but also returns the [`CredentialKind`] so callers can
+/// Like [`get_token`] but also returns the [`AuthMethod`] so callers can
 /// decide whether to include the `x-goog-user-project` quota header.
-pub async fn get_token_with_kind(scopes: &[&str]) -> anyhow::Result<(String, CredentialKind)> {
+pub async fn get_token_with_kind(scopes: &[&str]) -> anyhow::Result<(String, AuthMethod)> {
     if let Ok(token) = std::env::var("GOOGLE_WORKSPACE_CLI_TOKEN") {
         if !token.is_empty() {
-            return Ok((token, CredentialKind::UserOAuth));
+            return Ok((token, AuthMethod::OAuth));
         }
     }
 
@@ -255,8 +257,8 @@ pub async fn get_token_with_kind(scopes: &[&str]) -> anyhow::Result<(String, Cre
 
     let creds = load_credentials_inner(creds_file.as_deref(), &enc_path, &default_path).await?;
     let kind = match &creds {
-        Credential::ServiceAccount(_) => CredentialKind::ServiceAccount,
-        Credential::AuthorizedUser(_) => CredentialKind::UserOAuth,
+        Credential::ServiceAccount(_) => AuthMethod::ServiceAccount,
+        Credential::AuthorizedUser(_) => AuthMethod::OAuth,
     };
     let token = get_token_inner(scopes, creds, &token_cache).await?;
     Ok((token, kind))

--- a/crates/google-workspace-cli/src/auth.rs
+++ b/crates/google-workspace-cli/src/auth.rs
@@ -126,6 +126,15 @@ fn adc_well_known_path() -> Option<PathBuf> {
     })
 }
 
+/// What kind of credential provided the token.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CredentialKind {
+    /// Browser-based OAuth 2.0 user credential (from `gws auth login`)
+    UserOAuth,
+    /// Service-account key credential
+    ServiceAccount,
+}
+
 /// Types of credentials we support
 #[derive(Debug)]
 enum Credential {
@@ -227,6 +236,30 @@ pub async fn get_token(scopes: &[&str]) -> anyhow::Result<String> {
 
     let creds = load_credentials_inner(creds_file.as_deref(), &enc_path, &default_path).await?;
     get_token_inner(scopes, creds, &token_cache).await
+}
+
+/// Like [`get_token`] but also returns the [`CredentialKind`] so callers can
+/// decide whether to include the `x-goog-user-project` quota header.
+pub async fn get_token_with_kind(scopes: &[&str]) -> anyhow::Result<(String, CredentialKind)> {
+    if let Ok(token) = std::env::var("GOOGLE_WORKSPACE_CLI_TOKEN") {
+        if !token.is_empty() {
+            return Ok((token, CredentialKind::UserOAuth));
+        }
+    }
+
+    let creds_file = std::env::var("GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE").ok();
+    let config_dir = crate::auth_commands::config_dir();
+    let enc_path = credential_store::encrypted_credentials_path();
+    let default_path = config_dir.join("credentials.json");
+    let token_cache = config_dir.join("token_cache.json");
+
+    let creds = load_credentials_inner(creds_file.as_deref(), &enc_path, &default_path).await?;
+    let kind = match &creds {
+        Credential::ServiceAccount(_) => CredentialKind::ServiceAccount,
+        Credential::AuthorizedUser(_) => CredentialKind::UserOAuth,
+    };
+    let token = get_token_inner(scopes, creds, &token_cache).await?;
+    Ok((token, kind))
 }
 
 /// Check if HTTP proxy environment variables are set

--- a/crates/google-workspace-cli/src/executor.rs
+++ b/crates/google-workspace-cli/src/executor.rs
@@ -31,16 +31,7 @@ use crate::discovery::{RestDescription, RestMethod};
 use crate::error::GwsError;
 use crate::output::sanitize_for_terminal;
 
-/// Tracks what authentication method was used for the request.
-#[derive(Debug, Clone, PartialEq)]
-pub enum AuthMethod {
-    /// OAuth2 bearer token from a user credential (`gws auth login`)
-    OAuth,
-    /// Bearer token from a service-account key
-    ServiceAccount,
-    /// No authentication was provided
-    None,
-}
+pub use crate::auth::AuthMethod;
 
 /// Source for media upload content.
 ///

--- a/crates/google-workspace-cli/src/executor.rs
+++ b/crates/google-workspace-cli/src/executor.rs
@@ -180,12 +180,19 @@ async fn build_http_request(
         }
     }
 
-    // Only send quota project for service-account auth; OAuth users may not be
-    // IAM members of the project, so the header would trigger 403 errors.
-    if *auth_method == AuthMethod::ServiceAccount {
-        if let Some(quota_project) = crate::auth::get_quota_project() {
-            request = request.header("x-goog-user-project", quota_project);
-        }
+    // For service-account auth, always forward the quota project (env var, config, or ADC).
+    // For OAuth, only send when GOOGLE_WORKSPACE_PROJECT_ID is explicitly set — the user
+    // has opted in, so we honour it even though OAuth users may not be IAM members of every
+    // project.  Omit the header entirely when neither condition is met to avoid 403 errors.
+    let quota_project = match auth_method {
+        AuthMethod::ServiceAccount => crate::auth::get_quota_project(),
+        AuthMethod::OAuth => std::env::var("GOOGLE_WORKSPACE_PROJECT_ID")
+            .ok()
+            .filter(|s| !s.is_empty()),
+        AuthMethod::None => None,
+    };
+    if let Some(quota_project) = quota_project {
+        request = request.header("x-goog-user-project", quota_project);
     }
 
     let mut all_query_params = input.query_params.clone();
@@ -2396,11 +2403,16 @@ async fn test_get_does_not_set_content_length_zero() {
     );
 }
 
+/// Mutex to serialise tests that mutate GOOGLE_WORKSPACE_PROJECT_ID so they
+/// don't race with each other when the test binary runs its threads in parallel.
+static QUOTA_PROJECT_ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[tokio::test]
-async fn test_oauth_auth_does_not_set_quota_project_header() {
-    // Arrange: even if get_quota_project() would return a value, OAuth requests
-    // must NOT send x-goog-user-project because OAuth users are not necessarily
-    // IAM members of the project and the header would trigger 403 errors.
+async fn test_oauth_auth_does_not_set_quota_project_header_by_default() {
+    let _guard = QUOTA_PROJECT_ENV_MUTEX.lock().unwrap();
+    // Without GOOGLE_WORKSPACE_PROJECT_ID set, OAuth requests must omit x-goog-user-project
+    // because OAuth users are not necessarily IAM members of the project.
+    std::env::remove_var("GOOGLE_WORKSPACE_PROJECT_ID");
     let client = reqwest::Client::new();
     let method = RestMethod {
         http_method: "GET".to_string(),
@@ -2431,6 +2443,49 @@ async fn test_oauth_auth_does_not_set_quota_project_header() {
     let built = request.build().unwrap();
     assert!(
         built.headers().get("x-goog-user-project").is_none(),
-        "OAuth requests must not include x-goog-user-project header"
+        "OAuth requests must not include x-goog-user-project header when env var is not set"
+    );
+}
+
+#[tokio::test]
+async fn test_oauth_auth_sends_quota_project_when_env_var_explicitly_set() {
+    let _guard = QUOTA_PROJECT_ENV_MUTEX.lock().unwrap();
+    // When GOOGLE_WORKSPACE_PROJECT_ID is explicitly set, OAuth requests should
+    // honour it and send x-goog-user-project (the user opted in).
+    std::env::set_var("GOOGLE_WORKSPACE_PROJECT_ID", "my-explicit-project");
+    let client = reqwest::Client::new();
+    let method = RestMethod {
+        http_method: "GET".to_string(),
+        path: "files".to_string(),
+        ..Default::default()
+    };
+    let input = ExecutionInput {
+        full_url: "https://example.com/files".to_string(),
+        body: None,
+        params: Map::new(),
+        query_params: Vec::new(),
+        is_upload: false,
+    };
+
+    let request = build_http_request(
+        &client,
+        &method,
+        &input,
+        Some("fake-token"),
+        &AuthMethod::OAuth,
+        None,
+        0,
+        &None,
+    )
+    .await
+    .unwrap();
+
+    std::env::remove_var("GOOGLE_WORKSPACE_PROJECT_ID");
+
+    let built = request.build().unwrap();
+    assert_eq!(
+        built.headers().get("x-goog-user-project").and_then(|v| v.to_str().ok()),
+        Some("my-explicit-project"),
+        "OAuth requests must include x-goog-user-project when GOOGLE_WORKSPACE_PROJECT_ID is set"
     );
 }

--- a/crates/google-workspace-cli/src/executor.rs
+++ b/crates/google-workspace-cli/src/executor.rs
@@ -2405,6 +2405,7 @@ async fn test_get_does_not_set_content_length_zero() {
 
 /// Mutex to serialise tests that mutate GOOGLE_WORKSPACE_PROJECT_ID so they
 /// don't race with each other when the test binary runs its threads in parallel.
+#[cfg(test)]
 static QUOTA_PROJECT_ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[tokio::test]
@@ -2484,7 +2485,10 @@ async fn test_oauth_auth_sends_quota_project_when_env_var_explicitly_set() {
 
     let built = request.build().unwrap();
     assert_eq!(
-        built.headers().get("x-goog-user-project").and_then(|v| v.to_str().ok()),
+        built
+            .headers()
+            .get("x-goog-user-project")
+            .and_then(|v| v.to_str().ok()),
         Some("my-explicit-project"),
         "OAuth requests must include x-goog-user-project when GOOGLE_WORKSPACE_PROJECT_ID is set"
     );

--- a/crates/google-workspace-cli/src/executor.rs
+++ b/crates/google-workspace-cli/src/executor.rs
@@ -187,9 +187,12 @@ async fn build_http_request(
         }
     }
 
-    // Set quota project from ADC for billing/quota attribution
-    if let Some(quota_project) = crate::auth::get_quota_project() {
-        request = request.header("x-goog-user-project", quota_project);
+    // Only send quota project for ADC/service-account auth; OAuth users are not
+    // necessarily IAM members of the project, so the header causes 403 errors.
+    if *auth_method != AuthMethod::OAuth {
+        if let Some(quota_project) = crate::auth::get_quota_project() {
+            request = request.header("x-goog-user-project", quota_project);
+        }
     }
 
     let mut all_query_params = input.query_params.clone();
@@ -2397,5 +2400,44 @@ async fn test_get_does_not_set_content_length_zero() {
     assert!(
         built.headers().get("Content-Length").is_none(),
         "GET with no body should not have Content-Length header"
+    );
+}
+
+#[tokio::test]
+async fn test_oauth_auth_does_not_set_quota_project_header() {
+    // Arrange: even if get_quota_project() would return a value, OAuth requests
+    // must NOT send x-goog-user-project because OAuth users are not necessarily
+    // IAM members of the project and the header would trigger 403 errors.
+    let client = reqwest::Client::new();
+    let method = RestMethod {
+        http_method: "GET".to_string(),
+        path: "files".to_string(),
+        ..Default::default()
+    };
+    let input = ExecutionInput {
+        full_url: "https://example.com/files".to_string(),
+        body: None,
+        params: Map::new(),
+        query_params: Vec::new(),
+        is_upload: false,
+    };
+
+    let request = build_http_request(
+        &client,
+        &method,
+        &input,
+        Some("fake-token"),
+        &AuthMethod::OAuth,
+        None,
+        0,
+        &None,
+    )
+    .await
+    .unwrap();
+
+    let built = request.build().unwrap();
+    assert!(
+        built.headers().get("x-goog-user-project").is_none(),
+        "OAuth requests must not include x-goog-user-project header"
     );
 }

--- a/crates/google-workspace-cli/src/executor.rs
+++ b/crates/google-workspace-cli/src/executor.rs
@@ -34,8 +34,10 @@ use crate::output::sanitize_for_terminal;
 /// Tracks what authentication method was used for the request.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AuthMethod {
-    /// OAuth2 bearer token from credentials file
+    /// OAuth2 bearer token from a user credential (`gws auth login`)
     OAuth,
+    /// Bearer token from a service-account key
+    ServiceAccount,
     /// No authentication was provided
     None,
 }
@@ -182,14 +184,14 @@ async fn build_http_request(
     };
 
     if let Some(token) = token {
-        if *auth_method == AuthMethod::OAuth {
+        if matches!(*auth_method, AuthMethod::OAuth | AuthMethod::ServiceAccount) {
             request = request.bearer_auth(token);
         }
     }
 
-    // Only send quota project for ADC/service-account auth; OAuth users are not
-    // necessarily IAM members of the project, so the header causes 403 errors.
-    if *auth_method != AuthMethod::OAuth {
+    // Only send quota project for service-account auth; OAuth users may not be
+    // IAM members of the project, so the header would trigger 403 errors.
+    if *auth_method == AuthMethod::ServiceAccount {
         if let Some(quota_project) = crate::auth::get_quota_project() {
             request = request.header("x-goog-user-project", quota_project);
         }

--- a/crates/google-workspace-cli/src/main.rs
+++ b/crates/google-workspace-cli/src/main.rs
@@ -262,8 +262,14 @@ async fn run() -> Result<(), GwsError> {
     let scopes: Vec<&str> = select_scope(&method.scopes).into_iter().collect();
 
     // Authenticate: try OAuth, fail with error if credentials exist but are broken
-    let (token, auth_method) = match auth::get_token(&scopes).await {
-        Ok(t) => (Some(t), executor::AuthMethod::OAuth),
+    let (token, auth_method) = match auth::get_token_with_kind(&scopes).await {
+        Ok((t, kind)) => {
+            let method = match kind {
+                auth::CredentialKind::ServiceAccount => executor::AuthMethod::ServiceAccount,
+                auth::CredentialKind::UserOAuth => executor::AuthMethod::OAuth,
+            };
+            (Some(t), method)
+        }
         Err(e) => {
             // If credentials were found but failed (e.g. decryption error, invalid token),
             // propagate the error instead of silently falling back to unauthenticated.

--- a/crates/google-workspace-cli/src/main.rs
+++ b/crates/google-workspace-cli/src/main.rs
@@ -263,13 +263,7 @@ async fn run() -> Result<(), GwsError> {
 
     // Authenticate: try OAuth, fail with error if credentials exist but are broken
     let (token, auth_method) = match auth::get_token_with_kind(&scopes).await {
-        Ok((t, kind)) => {
-            let method = match kind {
-                auth::CredentialKind::ServiceAccount => executor::AuthMethod::ServiceAccount,
-                auth::CredentialKind::UserOAuth => executor::AuthMethod::OAuth,
-            };
-            (Some(t), method)
-        }
+        Ok((t, method)) => (Some(t), method),
         Err(e) => {
             // If credentials were found but failed (e.g. decryption error, invalid token),
             // propagate the error instead of silently falling back to unauthenticated.


### PR DESCRIPTION
## Summary

Picks up the fix from #827 (by @nuthalapativarun), which was auto-closed by the stale-bot after 72 hours of inactivity — not because it was rejected. The PR had already passed CI (fmt, clippy, tests) and been through several rounds of review addressing `gemini-code-assist` feedback.

**Root cause (from #827/#729):** the CLI unconditionally sends the `x-goog-user-project` header (from `project_id` in `client_secret.json`) on every request. For OAuth desktop-app credentials, this triggers a GCP IAM check (`serviceusage.services.use`) that fails for any user who isn't an IAM member of the project backing the shared OAuth client — a common setup when an OAuth client is distributed org-wide. The API then returns a permission error that, depending on the service, surfaces as `403 insufficientPermissions: Request had insufficient authentication scopes` even though the token's actual scopes are correct.

**New evidence this affects more than Drive:**
- #729's own thread shows it also breaks `admin-reports` (comment from @snacsnoc, same error, confirmed fixed by removing the header).
- I hit the identical symptom on `calendar.events.list` while debugging a `perf-tracker`-style tool that shells out to `gws`: every raw `<service> <resource> <method>` call to `calendar.events.list` failed with the exact same error, regardless of `calendarId` or date range, immediately after a fresh interactive OAuth consent that included the `calendar` scope — while the `+agenda` helper (which never sends `x-goog-user-project`) succeeded on the identical account and data. Filed as #861 with the isolated repro.

## Fix (unchanged from #827, plus two small follow-ups)

- `ServiceAccount`: always forward the quota project (env var, config, or ADC) — service accounts need it and are project members by construction.
- `OAuth`: only send `x-goog-user-project` when `GOOGLE_WORKSPACE_PROJECT_ID` is explicitly set (opt-in) — otherwise omit it entirely, since OAuth users may not be IAM members of the client's backing project.
- `None`: never send it.

On top of #827's four commits, I added:
- `#[cfg(test)]` on `QUOTA_PROJECT_ENV_MUTEX` — it's only referenced from `#[tokio::test]` functions, which aren't compiled outside test builds, so the plain `cargo clippy --workspace` (CI's lint job, no `--tests`/`--all-targets`) flagged it as dead code.
- A `cargo fmt` pass on the new test file's `assert_eq!` line wrap.

## Verification

- `cargo test -p google-workspace-cli`: 703 passed, 0 failed (includes the two regression tests from #827 covering both the default-omit and explicit-opt-in cases).
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace -- -D warnings` (CI's exact lint command): clean except for one pre-existing, unrelated `collapsible_match` warning in `helpers/script.rs` that I confirmed also fails on a fresh `origin/main` checkout without this branch — not introduced by this change.
- Branch is a clean fast-forward on top of current `origin/main` (no rebase conflicts).
- Built the patched binary locally and ran it against a real Google Calendar account that was previously failing 100% of the time on `calendar.events.list` with this exact error — it now succeeds consistently, including with the multi-week `maxResults`/`orderBy` params a real caller would use.

Fixes #729
Fixes #861
Related to the `admin-reports` case reported in https://github.com/googleworkspace/cli/issues/729#issuecomment-4330695878 (@snacsnoc)

Co-authored-by: Varun Nuthalapati <nuthalapativarun@gmail.com>
