### PR TITLE
fix: include service name in help usage

### DIFF
--- a/crates/google-workspace-cli/src/main.rs
+++ b/crates/google-workspace-cli/src/main.rs
@@ -155,8 +155,12 @@ async fn run() -> Result<(), GwsError> {
             .map_err(|e| GwsError::Discovery(format!("{e:#}")))?
     };
 
-    // Build the dynamic command tree (all commands shown regardless of auth state)
-    let cli = commands::build_cli(&doc);
+    // Build the dynamic command tree (all commands shown regardless of auth state).
+    // Clap only sees the service-specific subcommand tree after we strip the
+    // service name from argv below, so teach it the full binary invocation for
+    // help/usage rendering. Otherwise nested help text for commands such as
+    // `gws sheets spreadsheets --help` incorrectly starts at `gws spreadsheets`.
+    let cli = commands::build_cli(&doc).bin_name(format!("gws {first_arg}"));
 
     // Re-parse args (skip argv[0] which is the binary, and argv[1] which is the service name)
     // Filter out --api-version and its value


### PR DESCRIPTION
## Summary
Fixes #839

Ensure generated service help renders the full invocation path (for example, `gws sheets spreadsheets`) instead of dropping the service name after argv is filtered for Clap.

## Changes
- Set the service-specific Clap command tree `bin_name` to `gws <service>` before parsing filtered arguments.
- Keeps command parsing unchanged while correcting help/usage output for nested resources.

## Test Plan
- `cargo fmt -- --check`
- `cargo test -q` (blocked in this environment: linker `cc` is not installed, so Rust build scripts for dependencies fail before tests compile)
