### PR TITLE
feat(recipes): add suggest-doc-edits — propose Docs edits as quoting comments (Suggesting-mode API workaround)

### DIFF
--- a/.changeset/great-owls-suggest.md
+++ b/.changeset/great-owls-suggest.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Add `recipe-suggest-doc-edits`: propose Google Docs edits as Drive comments quoting the target text (workaround for the Docs API's lack of Suggesting-mode write support), then apply via batchUpdate after acceptance.

--- a/crates/google-workspace-cli/registry/recipes.toml
+++ b/crates/google-workspace-cli/registry/recipes.toml
@@ -494,3 +494,17 @@ steps = [
   "Write the report: `gws docs +write --document-id DOC_ID --text '## Sales Report - January 2025\n\n### Summary\nTotal deals: 45\nRevenue: $125,000\n\n### Top Deals\n1. Acme Corp - $25,000\n2. Widget Inc - $18,000'`",
   "Share with stakeholders: `gws drive permissions create --params '{\"fileId\": \"DOC_ID\"}' --json '{\"role\": \"reader\", \"type\": \"user\", \"emailAddress\": \"cfo@company.com\"}'`"
 ]
+
+[[recipes]]
+name = "suggest-doc-edits"
+title = "Suggest Edits on a Google Doc via Comments"
+description = "Propose edits on a Google Doc as review comments quoting the target text (the Docs API can't create suggestions)."
+category = "productivity"
+services = [ "docs", "drive" ]
+steps = [
+  "Note the API limitation: `documents.batchUpdate` makes direct edits only — tracked \"Suggesting-mode\" suggestions are UI-only (`suggestionsViewMode` exists only on the read path). Propose edits as comments instead.",
+  "Read the document to capture the exact current text to change: `gws docs documents get --params '{\"documentId\": \"DOC_ID\"}'`",
+  "Post each proposed edit as a comment quoting the target text: `gws drive comments create --params '{\"fileId\": \"DOC_ID\", \"fields\": \"id\"}' --json '{\"content\": \"SUGGESTED EDIT — replace with: NEW TEXT\", \"quotedFileContent\": {\"value\": \"EXACT CURRENT TEXT\"}}'`",
+  "After reviewers accept, apply the edit for real: `gws docs documents batchUpdate --params '{\"documentId\": \"DOC_ID\"}' --json '{\"requests\": [{\"replaceAllText\": {\"containsText\": {\"text\": \"EXACT CURRENT TEXT\", \"matchCase\": true}, \"replaceText\": \"NEW TEXT\"}}]}'`",
+  "Resolve the comment: `gws drive replies create --params '{\"fileId\": \"DOC_ID\", \"commentId\": \"COMMENT_ID\", \"fields\": \"id\"}' --json '{\"action\": \"resolve\", \"content\": \"Applied.\"}'`"
+]

--- a/skills/recipe-suggest-doc-edits/SKILL.md
+++ b/skills/recipe-suggest-doc-edits/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: recipe-suggest-doc-edits
+description: "Propose edits on a Google Doc as review comments quoting the target text (the Docs API can't create suggestions)."
+metadata:
+  version: 0.22.5
+  openclaw:
+    category: "recipe"
+    domain: "productivity"
+    requires:
+      bins:
+        - gws
+      skills:
+        - gws-docs
+        - gws-drive
+---
+
+# Suggest Edits on a Google Doc via Comments
+
+> **PREREQUISITE:** Load the following skills to execute this recipe: `gws-docs`, `gws-drive`
+
+Propose edits on a Google Doc as review comments quoting the target text (the Docs API can't create suggestions).
+
+## Steps
+
+1. Note the API limitation: `documents.batchUpdate` makes direct edits only — tracked "Suggesting-mode" suggestions are UI-only (`suggestionsViewMode` exists only on the read path). Propose edits as comments instead.
+2. Read the document to capture the exact current text to change: `gws docs documents get --params '{"documentId": "DOC_ID"}'`
+3. Post each proposed edit as a comment quoting the target text: `gws drive comments create --params '{"fileId": "DOC_ID", "fields": "id"}' --json '{"content": "SUGGESTED EDIT — replace with: NEW TEXT", "quotedFileContent": {"value": "EXACT CURRENT TEXT"}}'`
+4. After reviewers accept, apply the edit for real: `gws docs documents batchUpdate --params '{"documentId": "DOC_ID"}' --json '{"requests": [{"replaceAllText": {"containsText": {"text": "EXACT CURRENT TEXT", "matchCase": true}, "replaceText": "NEW TEXT"}}]}'`
+5. Resolve the comment: `gws drive replies create --params '{"fileId": "DOC_ID", "commentId": "COMMENT_ID", "fields": "id"}' --json '{"action": "resolve", "content": "Applied."}'`
+


### PR DESCRIPTION
## Description

Adds a `recipe-suggest-doc-edits` recipe covering a common agent task the API can't do natively: **the Docs API cannot create Suggesting-mode suggestions** (`documents.batchUpdate` = direct edits only; `suggestionsViewMode` is read-side only). The recipe documents the practical workaround:

1. `gws docs documents get` to capture the exact target text
2. `gws drive comments create` with `quotedFileContent` — each proposed edit lands as a review comment quoting the text it targets
3. after reviewer acceptance, `gws docs documents batchUpdate` (`replaceAllText`) applies it
4. `gws drive replies create` with `action: resolve` closes the loop

Verified end-to-end against a real Google Doc (5 suggested-edit comments posted via `quotedFileContent`, visible in the comment rail).

Changes: one `[[recipes]]` entry in `registry/recipes.toml` + the generated `skills/recipe-suggest-doc-edits/SKILL.md` (hand-rendered to match `render_recipe_skill`; description kept ≤120 chars to avoid frontmatter truncation).

**Dry Run Output:**
```json
// n/a — recipe/docs-only change, no new CLI command or request body
```

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly. *(no Rust changes — TOML + markdown only)*
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings. *(no Rust changes)*
- [x] I have added tests that prove my fix is effective or that my feature works. *(covered by the existing recipes.toml validation test; TOML parse verified locally)*
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.