### PR TITLE
docs: document Gmail web link vs API ID mismatch (#858)

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ gws drive --help      # shows +upload …
 | `modelarmor` | `+sanitize-response` | Sanitize a model response through a Model Armor template |
 | `modelarmor` | `+create-template` | Create a new Model Armor template |
 
-> **Gmail web links vs API IDs:** The API returns hex thread/message IDs (e.g. `19e1acd465710c93`). There is no supported way to turn these into durable Gmail web URLs. `#all/<hexId>` is unofficial and unreliable on cold loads. For the inverse problem (web URL IDs not accepted by the API), see [#790](https://github.com/googleworkspace/cli/issues/790).
+> **Gmail web links vs API IDs:** The API returns hex thread/message IDs (e.g. `19e1acd465710c93`). There is no supported way to turn these into durable Gmail web URLs. `#all/<hexId>` is unofficial and unreliable on cold loads. The closest option is `#search/rfc822msgid:<Message-ID>`, though it is a search URL, not a direct permalink. For the inverse problem (web URL IDs not accepted by the API), see [#790](https://github.com/googleworkspace/cli/issues/790).
 
 **Examples:**
 

--- a/README.md
+++ b/README.md
@@ -332,6 +332,8 @@ gws drive --help      # shows +upload …
 | `modelarmor` | `+sanitize-response` | Sanitize a model response through a Model Armor template |
 | `modelarmor` | `+create-template` | Create a new Model Armor template |
 
+> **Gmail web links vs API IDs:** The API returns hex thread/message IDs (e.g. `19e1acd465710c93`). There is no supported way to turn these into durable Gmail web URLs. `#all/<hexId>` is unofficial and unreliable on cold loads. For the inverse problem (web URL IDs not accepted by the API), see [#790](https://github.com/googleworkspace/cli/issues/790).
+
 **Examples:**
 
 ```bash

--- a/skills/gws-gmail/SKILL.md
+++ b/skills/gws-gmail/SKILL.md
@@ -45,6 +45,8 @@ gws gmail <resource> <method> [flags]
   - `settings` — Operations on the 'settings' resource
   - `threads` — Operations on the 'threads' resource
 
+> **Gmail web links vs API IDs:** The API returns hex thread/message IDs (e.g. `19e1acd465710c93`). There is no supported way to turn these into durable Gmail web URLs. `#all/<hexId>` is unofficial and unreliable on cold loads. For the inverse problem, see [#790](https://github.com/googleworkspace/cli/issues/790).
+
 ## Discovering Commands
 
 Before calling any API method, inspect it:

--- a/skills/gws-gmail/SKILL.md
+++ b/skills/gws-gmail/SKILL.md
@@ -45,7 +45,7 @@ gws gmail <resource> <method> [flags]
   - `settings` — Operations on the 'settings' resource
   - `threads` — Operations on the 'threads' resource
 
-> **Gmail web links vs API IDs:** The API returns hex thread/message IDs (e.g. `19e1acd465710c93`). There is no supported way to turn these into durable Gmail web URLs. `#all/<hexId>` is unofficial and unreliable on cold loads. For the inverse problem, see [#790](https://github.com/googleworkspace/cli/issues/790).
+> **Gmail web links vs API IDs:** The API returns hex thread/message IDs (e.g. `19e1acd465710c93`). There is no supported way to turn these into durable Gmail web URLs. `#all/<hexId>` is unofficial and unreliable on cold loads. The closest option is `#search/rfc822msgid:<Message-ID>`, though it is a search URL, not a direct permalink. For the inverse problem, see [#790](https://github.com/googleworkspace/cli/issues/790).
 
 ## Discovering Commands
 


### PR DESCRIPTION
Documents the mismatch between Gmail API hex IDs and web-based URLs. The API returns hex thread/message IDs but there is no supported way to convert them into stable Gmail web URLs.

Only README.md and skills/gws-gmail/SKILL.md are changed.

Closes #858

## Verification

- The docs explicitly state that '#all/<hexId>' is unofficial and unreliable
- The notes clarify why direct permalinks from API IDs are not supported