### PR TITLE
feat(cloudidentity): add Cloud Identity Groups API service alias

### DIFF
--- a/crates/google-workspace/src/services.rs
+++ b/crates/google-workspace/src/services.rs
@@ -59,6 +59,12 @@ pub const SERVICES: &[ServiceEntry] = &[
         description: "Audit logs and usage reports",
     },
     ServiceEntry {
+        aliases: &["cloud-identity", "cloudidentity"],
+        api_name: "cloudidentity",
+        version: "v1",
+        description: "Manage Cloud Identity groups and memberships",
+    },
+    ServiceEntry {
         aliases: &["docs"],
         api_name: "docs",
         version: "v1",
@@ -173,6 +179,14 @@ mod tests {
         assert_eq!(
             resolve_service("reports").unwrap(),
             ("admin".to_string(), "reports_v1".to_string())
+        );
+        assert_eq!(
+            resolve_service("cloud-identity").unwrap(),
+            ("cloudidentity".to_string(), "v1".to_string())
+        );
+        assert_eq!(
+            resolve_service("cloudidentity").unwrap(),
+            ("cloudidentity".to_string(), "v1".to_string())
         );
     }
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -14,6 +14,7 @@ Core Google Workspace API skills.
 | [gws-gmail](../skills/gws-gmail/SKILL.md) | Gmail: Send, read, and manage email. |
 | [gws-calendar](../skills/gws-calendar/SKILL.md) | Google Calendar: Manage calendars and events. |
 | [gws-admin-reports](../skills/gws-admin-reports/SKILL.md) | Google Workspace Admin SDK: Audit logs and usage reports. |
+| [gws-cloud-identity](../skills/gws-cloud-identity/SKILL.md) | Google Cloud Identity: Manage Cloud Identity groups and memberships. |
 | [gws-docs](../skills/gws-docs/SKILL.md) | Read and write Google Docs. |
 | [gws-slides](../skills/gws-slides/SKILL.md) | Google Slides: Read and write presentations. |
 | [gws-tasks](../skills/gws-tasks/SKILL.md) | Google Tasks: Manage task lists and tasks. |

--- a/skills/gws-cloud-identity-search-groups/SKILL.md
+++ b/skills/gws-cloud-identity-search-groups/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: gws-cloud-identity-search-groups
+description: "Cloud Identity: Search which Google Groups a user belongs to (no admin privileges required)."
+metadata:
+  version: 0.22.5
+  openclaw:
+    category: "productivity"
+    requires:
+      bins:
+        - gws
+    cliHelp: "gws cloud-identity groups memberships searchDirectGroups --help"
+---
+
+# cloud-identity groups memberships searchDirectGroups
+
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+
+Lists the Google Groups (and other Cloud Identity groups) a given user directly
+belongs to — the same view as the "My Groups" page at
+https://groups.google.com. Unlike the Admin SDK Directory API, this works for
+any authenticated user asking about their own membership: no super-admin or
+delegated-admin role is required. Groups the caller isn't allowed to see are
+silently omitted from the response rather than causing an error.
+
+## Usage
+
+```bash
+gws cloud-identity groups memberships searchDirectGroups \
+  --params '{"parent":"groups/-","query":"member_key_id == '\''<email>'\''"}'
+```
+
+`parent` is always the literal string `groups/-` (the API searches across all
+groups for the given member — it is not a real resource ID). `query` is a CEL
+expression; at minimum set `member_key_id` to the email address you want to
+search.
+
+## Required scope
+
+Needs the `https://www.googleapis.com/auth/cloud-identity.groups.readonly`
+OAuth scope (or the read/write `cloud-identity.groups` scope) and the Cloud
+Identity API enabled on the backing GCP project. Neither Admin SDK Directory
+scopes nor a Workspace admin role are required — that's the point of this
+endpoint over the Admin Directory API's `groups.list`.
+
+## Known gotcha: the documented label filter breaks
+
+Google's own docs show a query like:
+
+```
+member_key_id == '<email>' && 'cloudidentity.googleapis.com/groups.discussion_forum' in labels
+```
+
+As of this API version, adding that `&& '...' in labels` clause returns a
+`400 INVALID_ARGUMENT` (confirmed against the live API directly, bypassing
+`gws`, to rule out a CLI bug). Use the bare `member_key_id == '<email>'`
+clause instead — it already returns only the groups the caller can see, which
+in practice are the Google Groups the user belongs to.
+
+## Examples
+
+```bash
+# Your own group memberships
+gws cloud-identity groups memberships searchDirectGroups \
+  --params '{"parent":"groups/-","query":"member_key_id == '\''me@example.com'\''"}'
+
+# Trim the response and paginate if the user belongs to 100+ groups
+gws cloud-identity groups memberships searchDirectGroups \
+  --params '{"parent":"groups/-","query":"member_key_id == '\''me@example.com'\''","fields":"memberships(groupKey,displayName,roles),nextPageToken"}' \
+  --page-all
+```
+
+## Tips
+
+- Read-only — never modifies group membership.
+- `searchTransitiveGroups` (nested/group-of-a-group membership) lives on the
+  same resource but requires a Workspace Enterprise or Cloud Identity Premium
+  SKU — it returned `403 PERMISSION_DENIED` on a standard account in testing.
+  Prefer `searchDirectGroups` unless you specifically need transitive
+  membership and know your SKU supports it.
+- For anything beyond the caller's own membership (auditing another user's
+  groups, listing a group's full roster), the caller needs visibility into
+  that group's membership — Google filters out what it can't see rather than
+  erroring.
+- `--fields` is a query parameter, not a CLI flag — put it inside `--params`,
+  not on the command line.
+
+## See Also
+
+- [gws-shared](../gws-shared/SKILL.md) — Global flags and auth
+- [gws-cloud-identity](../gws-cloud-identity/SKILL.md) — All Cloud Identity groups/devices/policies commands

--- a/skills/gws-cloud-identity/SKILL.md
+++ b/skills/gws-cloud-identity/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: gws-cloud-identity
+description: "Google Cloud Identity: Manage Cloud Identity groups and memberships."
+metadata:
+  version: 0.22.5
+  openclaw:
+    category: "productivity"
+    requires:
+      bins:
+        - gws
+    cliHelp: "gws cloud-identity --help"
+---
+
+# cloud-identity (v1)
+
+> **PREREQUISITE:** Read `../gws-shared/SKILL.md` for auth, global flags, and security rules. If missing, run `gws generate-skills` to create it.
+
+```bash
+gws cloud-identity <resource> <method> [flags]
+```
+
+## API Resources
+
+### customers
+
+  - `userinvitations` — Operations on the 'userinvitations' resource
+
+### devices
+
+  - `cancelWipe` — Cancels an unfinished device wipe. This operation can be used to cancel device wipe in the gap between the wipe operation returning success and the device being wiped. This operation is possible when the device is in a "pending wipe" state. The device enters the "pending wipe" state when a wipe device command is issued, but has not yet been sent to the device. The cancel wipe will fail if the wipe command has already been issued to the device.
+  - `create` — Creates a device. Only company-owned device may be created. **Note**: This method is available only to customers who have one of the following SKUs: Enterprise Standard, Enterprise Plus, Enterprise for Education, and Cloud Identity Premium
+  - `delete` — Deletes the specified device.
+  - `get` — Retrieves the specified device.
+  - `list` — Lists/Searches devices.
+  - `wipe` — Wipes all data on the specified device.
+  - `deviceUsers` — Operations on the 'deviceUsers' resource
+
+### groups
+
+  - `create` — Creates a Group.
+  - `delete` — Deletes a `Group`.
+  - `get` — Retrieves a `Group`.
+  - `getSecuritySettings` — Get Security Settings
+  - `list` — Lists the `Group` resources under a customer or namespace.
+  - `lookup` — Looks up the [resource name](https://cloud.google.com/apis/design/resource_names) of a `Group` by its `EntityKey`.
+  - `patch` — Updates a `Group`.
+  - `search` — Searches for `Group` resources matching a specified query.
+  - `updateSecuritySettings` — Update Security Settings
+  - `memberships` — Operations on the 'memberships' resource
+
+### inboundOidcSsoProfiles
+
+  - `create` — Creates an InboundOidcSsoProfile for a customer. When the target customer has enabled [Multi-party approval for sensitive actions](https://support.google.com/a/answer/13790448), the `Operation` in the response will have `"done": false`, it will not have a response, and the metadata will have `"state": "awaiting-multi-party-approval"`.
+  - `delete` — Deletes an InboundOidcSsoProfile.
+  - `get` — Gets an InboundOidcSsoProfile.
+  - `list` — Lists InboundOidcSsoProfile objects for a Google enterprise customer.
+  - `patch` — Updates an InboundOidcSsoProfile. When the target customer has enabled [Multi-party approval for sensitive actions](https://support.google.com/a/answer/13790448), the `Operation` in the response will have `"done": false`, it will not have a response, and the metadata will have `"state": "awaiting-multi-party-approval"`.
+
+### inboundSamlSsoProfiles
+
+  - `create` — Creates an InboundSamlSsoProfile for a customer. When the target customer has enabled [Multi-party approval for sensitive actions](https://support.google.com/a/answer/13790448), the `Operation` in the response will have `"done": false`, it will not have a response, and the metadata will have `"state": "awaiting-multi-party-approval"`.
+  - `delete` — Deletes an InboundSamlSsoProfile.
+  - `get` — Gets an InboundSamlSsoProfile.
+  - `list` — Lists InboundSamlSsoProfiles for a customer.
+  - `patch` — Updates an InboundSamlSsoProfile. When the target customer has enabled [Multi-party approval for sensitive actions](https://support.google.com/a/answer/13790448), the `Operation` in the response will have `"done": false`, it will not have a response, and the metadata will have `"state": "awaiting-multi-party-approval"`.
+  - `idpCredentials` — Operations on the 'idpCredentials' resource
+
+### inboundSsoAssignments
+
+  - `create` — Creates an InboundSsoAssignment for users and devices in a `Customer` under a given `Group` or `OrgUnit`.
+  - `delete` — Deletes an InboundSsoAssignment. To disable SSO, Create (or Update) an assignment that has `sso_mode` == `SSO_OFF`.
+  - `get` — Gets an InboundSsoAssignment.
+  - `list` — Lists the InboundSsoAssignments for a `Customer`.
+  - `patch` — Updates an InboundSsoAssignment. The body of this request is the `inbound_sso_assignment` field and the `update_mask` is relative to that. For example: a PATCH to `/v1/inboundSsoAssignments/0abcdefg1234567&update_mask=rank` with a body of `{ "rank": 1 }` moves that (presumably group-targeted) SSO assignment to the highest priority and shifts any other group-targeted assignments down in priority.
+
+### policies
+
+  - `create` — Create a policy.
+  - `delete` — Delete a policy.
+  - `get` — Get a policy.
+  - `list` — List policies.
+  - `patch` — Update a policy.
+
+## Discovering Commands
+
+Before calling any API method, inspect it:
+
+```bash
+# Browse resources and methods
+gws cloud-identity --help
+
+# Inspect a method's required params, types, and defaults
+gws schema cloud-identity.<resource>.<method>
+```
+
+Use `gws schema` output to build your `--params` and `--json` flags.
+


### PR DESCRIPTION
Registers `cloud-identity`/`cloudidentity` (cloudidentity/v1) in the service registry, exposing groups, memberships, devices, and policies commands. Lets users search their own Google Groups memberships via groups.memberships.searchDirectGroups without needing Admin SDK Directory scopes or a Workspace admin role.

Adds a generated resource-reference skill plus a hand-written skill documenting the searchDirectGroups query pattern and a label-filter bug in the documented CEL query syntax.

Relates to #844

## Description

Please include a summary of the change and which issue is fixed. If adding a new feature or command, please include the output of running it with `--dry-run` to prove the JSON request body matches the Discovery Document schema.

**Dry Run Output:**
```json
// Paste --dry-run output here if applicable
```

## Checklist:

- [ ] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [ ] I have run `cargo fmt --all` to format the code perfectly.
- [ ] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.
