### PR TITLE
fix: don't use oauth client project_id as quota project

### DIFF
--- a/.changeset/no-quota-project-for-oauth.md
+++ b/.changeset/no-quota-project-for-oauth.md
@@ -1,0 +1,14 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Stop sending `x-goog-user-project` derived from the OAuth client's `project_id`
+
+The `project_id` in `client_secret.json` was used as the quota project on every request.
+The API only honors that header when the authenticated end user holds
+`serviceusage.services.use` on the project, so users who are not IAM members of it
+received a 403 on every call. Quota for end-user OAuth credentials is already attributed
+via the OAuth client ID.
+
+The header is still sent for ADC credentials with a `quota_project_id`, and can be set
+explicitly via `GOOGLE_WORKSPACE_PROJECT_ID`.

--- a/crates/google-workspace-cli/src/auth.rs
+++ b/crates/google-workspace-cli/src/auth.rs
@@ -938,8 +938,10 @@ mod tests {
             tmp.path().to_str().unwrap(),
         );
         let _env_guard = EnvVarGuard::remove("GOOGLE_WORKSPACE_PROJECT_ID");
-        let _adc_guard = EnvVarGuard::remove("GOOGLE_APPLICATION_CREDENTIALS");
-        let _home_guard = EnvVarGuard::set("HOME", "/missing/home");
+        let _adc_guard = EnvVarGuard::set(
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            tmp.path().join("missing-adc.json").to_str().unwrap(),
+        );
 
         // Save a client config with a project ID
         crate::oauth_config::save_client_config("id", "secret", "config-project").unwrap();
@@ -956,8 +958,10 @@ mod tests {
             tmp.path().to_str().unwrap(),
         );
         let _env_guard = EnvVarGuard::set("GOOGLE_WORKSPACE_PROJECT_ID", "explicit-project");
-        let _adc_guard = EnvVarGuard::remove("GOOGLE_APPLICATION_CREDENTIALS");
-        let _home_guard = EnvVarGuard::set("HOME", "/missing/home");
+        let _adc_guard = EnvVarGuard::set(
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            tmp.path().join("missing-adc.json").to_str().unwrap(),
+        );
 
         crate::oauth_config::save_client_config("id", "secret", "config-project").unwrap();
 

--- a/crates/google-workspace-cli/src/auth.rs
+++ b/crates/google-workspace-cli/src/auth.rs
@@ -84,8 +84,10 @@ async fn refresh_token_with_reqwest(
 ///
 /// Priority:
 /// 1. `GOOGLE_WORKSPACE_PROJECT_ID` environment variable.
-/// 2. `project_id` from the OAuth client configuration (`client_secret.json`).
-/// 3. `quota_project_id` from Application Default Credentials (ADC).
+/// 2. `quota_project_id` from Application Default Credentials (ADC).
+///
+/// The `project_id` from the OAuth client configuration (`client_secret.json`) is not
+/// used: quota for end-user OAuth credentials is attributed via the OAuth client ID.
 pub fn get_quota_project() -> Option<String> {
     // 1. Explicit environment variable (highest priority)
     if let Ok(project_id) = std::env::var("GOOGLE_WORKSPACE_PROJECT_ID") {
@@ -94,14 +96,7 @@ pub fn get_quota_project() -> Option<String> {
         }
     }
 
-    // 2. Project ID from the OAuth client configuration (set via `gws auth setup`)
-    if let Ok(config) = crate::oauth_config::load_client_config() {
-        if !config.project_id.is_empty() {
-            return Some(config.project_id);
-        }
-    }
-
-    // 3. Fallback to Application Default Credentials (ADC)
+    // 2. Fallback to Application Default Credentials (ADC)
     let path = std::env::var("GOOGLE_APPLICATION_CREDENTIALS")
         .ok()
         .map(PathBuf::from)
@@ -936,7 +931,7 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn test_get_quota_project_priority_config() {
+    fn test_get_quota_project_ignores_client_config() {
         let tmp = tempfile::tempdir().unwrap();
         let _config_guard = EnvVarGuard::set(
             "GOOGLE_WORKSPACE_CLI_CONFIG_DIR",
@@ -949,7 +944,24 @@ mod tests {
         // Save a client config with a project ID
         crate::oauth_config::save_client_config("id", "secret", "config-project").unwrap();
 
-        assert_eq!(get_quota_project(), Some("config-project".to_string()));
+        assert_eq!(get_quota_project(), None);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_get_quota_project_env_var_overrides_client_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _config_guard = EnvVarGuard::set(
+            "GOOGLE_WORKSPACE_CLI_CONFIG_DIR",
+            tmp.path().to_str().unwrap(),
+        );
+        let _env_guard = EnvVarGuard::set("GOOGLE_WORKSPACE_PROJECT_ID", "explicit-project");
+        let _adc_guard = EnvVarGuard::remove("GOOGLE_APPLICATION_CREDENTIALS");
+        let _home_guard = EnvVarGuard::set("HOME", "/missing/home");
+
+        crate::oauth_config::save_client_config("id", "secret", "config-project").unwrap();
+
+        assert_eq!(get_quota_project(), Some("explicit-project".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #729.

### Problem

`get_quota_project()` returns the `project_id` from `client_secret.json`, which is then sent as `x-goog-user-project` on every API request. Google only honors that header if the **authenticated end user** holds `serviceusage.services.use` on that project, so any user who is not an IAM member of the project gets:

```
403 Caller does not have required permission to use project <project>.
Grant the caller the roles/serviceusage.serviceUsageConsumer role, or a custom
role with the serviceusage.services.use permission
```

This affects every command. It is invisible to the project owner (who has the permission implicitly) and breaks every other user, including anyone distributing an OAuth client to end users.

### Repro

1. `gws auth setup` / `gws auth login` with an OAuth client from project P.
2. Authenticate as a user who is not an IAM member of P.
3. `gws drive files list --params '{"pageSize":1}'` → 403 as above.

Verified against a live account before/after with the same credentials and command — only the binary differs.

### Fix

Drop `client_secret.json`'s `project_id` as a quota-project source. Workspace APIs already attribute quota via the OAuth client ID, so the header is unnecessary for end-user OAuth credentials.

Both legitimate sources are kept:
- `GOOGLE_WORKSPACE_PROJECT_ID` — explicit opt-in, any credential type
- ADC `quota_project_id` — service accounts / ADC, where the header is genuinely required

### Compatibility

This is a behavior change for anyone whose end users *do* hold `serviceUsageConsumer` and who relies on quota being billed to the client-secret project. They can restore the old behavior by setting `GOOGLE_WORKSPACE_PROJECT_ID`. I filed it as a `patch` changeset as a bug fix, but happy to relabel if you'd prefer `minor`.

### Tests

- `test_get_quota_project_priority_config` → `test_get_quota_project_ignores_client_config`, now asserts `None`
- added `test_get_quota_project_env_var_overrides_client_config`

Both pass. Note: `test_get_quota_project_reads_adc` and `test_get_quota_project_priority_adc_fallback` fail on Windows both before and after this change — the tests set `HOME`, but `dirs::home_dir()` reads `USERPROFILE` on Windows, so the temp ADC file is never found. Unrelated to this patch; happy to open a separate issue.
