### PR TITLE
feat(auth): customize the OAuth callback for remote-host logins

### DIFF
--- a/.changeset/oauth-redirect-override.md
+++ b/.changeset/oauth-redirect-override.md
@@ -2,4 +2,4 @@
 "@googleworkspace/cli": minor
 ---
 
-Allow customizing the `gws auth login` OAuth callback so it works when the CLI runs on a remote host whose `localhost` the browser connot reach directly: `GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI` overrides the redirect URI sent to Google, `GOOGLE_WORKSPACE_CLI_OAUTH_STATE` sets the `state` value passed through to the auth URL, and `GOOGLE_WORKSPACE_CLI_OAUTH_PORT` pins the local callback (loopback) port.
+Allow customizing the `gws auth login` OAuth callback so it works when the CLI runs on a remote host whose `localhost` the browser connot reach directly: `GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI` overrides the redirect URI sent to Google, `GOOGLE_WORKSPACE_CLI_OAUTH_STATE` sets the `state` value passed to the OAuth server, and `GOOGLE_WORKSPACE_CLI_OAUTH_PORT` pins the local callback port. When a custom `state` is set, the value returned on the callback is verified against it to reject forged (CSRF) responses.

--- a/.changeset/oauth-redirect-override.md
+++ b/.changeset/oauth-redirect-override.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": minor
+---
+
+Support overriding the OAuth redirect target via `GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI`, `GOOGLE_WORKSPACE_CLI_OAUTH_STATE`, and `GOOGLE_WORKSPACE_CLI_OAUTH_PORT`, so `gws auth login` can route through an external OAuth redirector (e.g. from a remote dev environment). Also percent-decode the authorization code from the callback so codes that pass through a redirector are exchanged correctly.

--- a/.changeset/oauth-redirect-override.md
+++ b/.changeset/oauth-redirect-override.md
@@ -2,4 +2,4 @@
 "@googleworkspace/cli": minor
 ---
 
-Support overriding the OAuth redirect target via `GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI`, `GOOGLE_WORKSPACE_CLI_OAUTH_STATE`, and `GOOGLE_WORKSPACE_CLI_OAUTH_PORT`, so `gws auth login` can route through an external OAuth redirector (e.g. from a remote dev environment). Also percent-decode the authorization code from the callback so codes that pass through a redirector are exchanged correctly.
+Allow customizing the `gws auth login` OAuth callback so it works when the CLI runs on a remote host whose `localhost` the browser connot reach directly: `GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI` overrides the redirect URI sent to Google, `GOOGLE_WORKSPACE_CLI_OAUTH_STATE` sets the `state` value passed through to the auth URL, and `GOOGLE_WORKSPACE_CLI_OAUTH_PORT` pins the local callback (loopback) port.

--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@
 # GOOGLE_WORKSPACE_CLI_CLIENT_SECRET=
 
 # ── OAuth callback customization (for remote-host logins) ─────────
-# Override the redirect URI sent to Google, set a state value passed through to the auth URL, and/or pin the local callback port.
+# Override the redirect URI sent to Google, set a state value passed to the OAuth server (verified on the callback), and/or pin the local callback port.
 # GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI=
 # GOOGLE_WORKSPACE_CLI_OAUTH_STATE=
 # GOOGLE_WORKSPACE_CLI_OAUTH_PORT=

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,13 @@
 # GOOGLE_WORKSPACE_CLI_CLIENT_ID=
 # GOOGLE_WORKSPACE_CLI_CLIENT_SECRET=
 
+# ── OAuth redirect override (e.g. remote dev via a redirector) ─────
+# Override the redirect_uri sent to Google, an opaque state value passed
+# through to the auth URL, and/or pin the local callback port.
+# GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI=
+# GOOGLE_WORKSPACE_CLI_OAUTH_STATE=
+# GOOGLE_WORKSPACE_CLI_OAUTH_PORT=
+
 # ── Configuration ─────────────────────────────────────────────────
 # Override the config directory (default: ~/.config/gws)
 # GOOGLE_WORKSPACE_CLI_CONFIG_DIR=

--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,8 @@
 # GOOGLE_WORKSPACE_CLI_CLIENT_ID=
 # GOOGLE_WORKSPACE_CLI_CLIENT_SECRET=
 
-# ── OAuth redirect override (e.g. remote dev via a redirector) ─────
-# Override the redirect_uri sent to Google, an opaque state value passed
-# through to the auth URL, and/or pin the local callback port.
+# ── OAuth callback customization (for remote-host logins) ─────────
+# Override the redirect URI sent to Google, set a state value passed through to the auth URL, and/or pin the local callback port.
 # GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI=
 # GOOGLE_WORKSPACE_CLI_OAUTH_STATE=
 # GOOGLE_WORKSPACE_CLI_OAUTH_PORT=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,8 +215,8 @@ See [`src/helpers/README.md`](crates/google-workspace-cli/src/helpers/README.md)
 |---|---|
 | `GOOGLE_WORKSPACE_CLI_CLIENT_ID` | OAuth client ID (for `gws auth login` when no `client_secret.json` is saved) |
 | `GOOGLE_WORKSPACE_CLI_CLIENT_SECRET` | OAuth client secret (paired with `CLIENT_ID` above) |
-| `GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI` | Override the OAuth `redirect_uri` (e.g. route through an external redirector) |
-| `GOOGLE_WORKSPACE_CLI_OAUTH_STATE` | Opaque OAuth `state` value passed through to the auth URL |
+| `GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI` | Override the OAuth redirect URI (for remote-host logins) |
+| `GOOGLE_WORKSPACE_CLI_OAUTH_STATE` | OAuth `state` value, passed through to the auth URL |
 | `GOOGLE_WORKSPACE_CLI_OAUTH_PORT` | Pin the local OAuth callback port (default: random) |
 
 ### Sanitization (Model Armor)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,9 @@ See [`src/helpers/README.md`](crates/google-workspace-cli/src/helpers/README.md)
 |---|---|
 | `GOOGLE_WORKSPACE_CLI_CLIENT_ID` | OAuth client ID (for `gws auth login` when no `client_secret.json` is saved) |
 | `GOOGLE_WORKSPACE_CLI_CLIENT_SECRET` | OAuth client secret (paired with `CLIENT_ID` above) |
+| `GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI` | Override the OAuth `redirect_uri` (e.g. route through an external redirector) |
+| `GOOGLE_WORKSPACE_CLI_OAUTH_STATE` | Opaque OAuth `state` value passed through to the auth URL |
+| `GOOGLE_WORKSPACE_CLI_OAUTH_PORT` | Pin the local OAuth callback port (default: random) |
 
 ### Sanitization (Model Armor)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,7 +216,7 @@ See [`src/helpers/README.md`](crates/google-workspace-cli/src/helpers/README.md)
 | `GOOGLE_WORKSPACE_CLI_CLIENT_ID` | OAuth client ID (for `gws auth login` when no `client_secret.json` is saved) |
 | `GOOGLE_WORKSPACE_CLI_CLIENT_SECRET` | OAuth client secret (paired with `CLIENT_ID` above) |
 | `GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI` | Override the OAuth redirect URI (for remote-host logins) |
-| `GOOGLE_WORKSPACE_CLI_OAUTH_STATE` | OAuth `state` value, passed through to the auth URL |
+| `GOOGLE_WORKSPACE_CLI_OAUTH_STATE` | OAuth `state` value, passed to the OAuth server and verified on the callback |
 | `GOOGLE_WORKSPACE_CLI_OAUTH_PORT` | Pin the local OAuth callback port (default: random) |
 
 ### Sanitization (Model Armor)

--- a/README.md
+++ b/README.md
@@ -381,8 +381,8 @@ All variables are optional. See [`.env.example`](.env.example) for a copy-paste 
 | `GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE` | Path to OAuth credentials JSON (user or service account) |
 | `GOOGLE_WORKSPACE_CLI_CLIENT_ID` | OAuth client ID (alternative to `client_secret.json`) |
 | `GOOGLE_WORKSPACE_CLI_CLIENT_SECRET` | OAuth client secret (paired with `CLIENT_ID`) |
-| `GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI` | Override the OAuth `redirect_uri` (e.g. route through an external redirector) |
-| `GOOGLE_WORKSPACE_CLI_OAUTH_STATE` | Opaque OAuth `state` value passed through to the auth URL |
+| `GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI` | Override the OAuth redirect URI (for remote-host logins) |
+| `GOOGLE_WORKSPACE_CLI_OAUTH_STATE` | OAuth `state` value, passed through to the auth URL |
 | `GOOGLE_WORKSPACE_CLI_OAUTH_PORT` | Pin the local OAuth callback port (default: random) |
 | `GOOGLE_WORKSPACE_CLI_CONFIG_DIR` | Override config directory (default: `~/.config/gws`) |
 | `GOOGLE_WORKSPACE_CLI_SANITIZE_TEMPLATE` | Default Model Armor template |

--- a/README.md
+++ b/README.md
@@ -190,19 +190,19 @@ If scope checkboxes appear, select required scopes (or **Select all**) before co
 
 ### Remote host (browser on another machine)
 
-When the CLI runs where the browser cannot reach via `localhost` (e.g. a cloud development environment), tell the OAuth server to redirect the authorization code to the CLI's host:
+When the CLI runs where the browser cannot reach it via `localhost` (e.g. a cloud development environment), point the OAuth redirect at an address the browser can reach, which delivers the authorization code back to the CLI:
 
 ```bash
 # Where Google sends the browser (must be an authorized redirect URI on the OAuth client)
-export GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI="https://example.com/callback"
-# Optional value passed through to the listening server (see OAuth 2.0 docs)
+export GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI="https://example.com/callback"k
+# Optional value passed to the OAuth server and verified when returned on the callback
 export GOOGLE_WORKSPACE_CLI_OAUTH_STATE="$STATE"
 # Optional port for the CLI's callback server
 export GOOGLE_WORKSPACE_CLI_OAUTH_PORT=42067
 gws auth login
 ```
 
-This flow requires a web application OAuth client that would allow redirects to URIs other than `http://localhost`. Provide the client's details via `GOOGLE_WORKSPACE_CLI_CLIENT_ID` and `GOOGLE_WORKSPACE_CLI_CLIENT_SECRET` environment variables.
+This flow requires a web application OAuth client that allows redirects to URIs other than `http://localhost`. Provide the client's details via `GOOGLE_WORKSPACE_CLI_CLIENT_ID` and `GOOGLE_WORKSPACE_CLI_CLIENT_SECRET` environment variables.
 
 ### Service Account (server-to-server)
 
@@ -399,7 +399,7 @@ All variables are optional. See [`.env.example`](.env.example) for a copy-paste 
 | `GOOGLE_WORKSPACE_CLI_CLIENT_ID` | OAuth client ID (alternative to `client_secret.json`) |
 | `GOOGLE_WORKSPACE_CLI_CLIENT_SECRET` | OAuth client secret (paired with `CLIENT_ID`) |
 | `GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI` | Override the OAuth redirect URI (for remote-host logins) |
-| `GOOGLE_WORKSPACE_CLI_OAUTH_STATE` | OAuth `state` value, passed through to the auth URL |
+| `GOOGLE_WORKSPACE_CLI_OAUTH_STATE` | OAuth `state` value, passed to the OAuth server and verified on the callback |
 | `GOOGLE_WORKSPACE_CLI_OAUTH_PORT` | Pin the local OAuth callback port (default: random) |
 | `GOOGLE_WORKSPACE_CLI_CONFIG_DIR` | Override config directory (default: `~/.config/gws`) |
 | `GOOGLE_WORKSPACE_CLI_SANITIZE_TEMPLATE` | Default Model Armor template |

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The CLI supports multiple auth workflows so it works on your laptop, in CI, and 
 | A GCP project but no `gcloud` | [Manual OAuth setup](#manual-oauth-setup-google-cloud-console) |
 | An existing OAuth access token | [`GOOGLE_WORKSPACE_CLI_TOKEN`](#pre-obtained-access-token) |
 | Existing Credentials | [`GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE`](#service-account-server-to-server) |
+| A remote host unreachable via `localhost` from my browser | [Remote host](#remote-host-browser-on-another-machine) |
 
 ### Interactive (local desktop)
 
@@ -186,6 +187,22 @@ If scope checkboxes appear, select required scopes (or **Select all**) before co
    export GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE=/path/to/credentials.json
    gws drive files list   # just works
    ```
+
+### Remote host (browser on another machine)
+
+When the CLI runs where the browser cannot reach via `localhost` (e.g. a cloud development environment), tell the OAuth server to redirect the authorization code to the CLI's host:
+
+```bash
+# Where Google sends the browser (must be an authorized redirect URI on the OAuth client)
+export GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI="https://example.com/callback"
+# Optional value passed through to the listening server (see OAuth 2.0 docs)
+export GOOGLE_WORKSPACE_CLI_OAUTH_STATE="$STATE"
+# Optional port for the CLI's callback server
+export GOOGLE_WORKSPACE_CLI_OAUTH_PORT=42067
+gws auth login
+```
+
+This flow requires a web application OAuth client that would allow redirects to URIs other than `http://localhost`. Provide the client's details via `GOOGLE_WORKSPACE_CLI_CLIENT_ID` and `GOOGLE_WORKSPACE_CLI_CLIENT_SECRET` environment variables.
 
 ### Service Account (server-to-server)
 
@@ -459,6 +476,8 @@ gws auth login --scopes drive,gmail,calendar
 ### `redirect_uri_mismatch`
 
 The OAuth client was not created as a **Desktop app** type. In the [Credentials](https://console.cloud.google.com/apis/credentials) page, delete the existing client, create a new one with type **Desktop app**, and download the new JSON.
+
+Using the [remote-host flow](#remote-host-browser-on-another-machine) instead? There it means the URL in `GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI` is not registered on your **Web application** client - add it under **Authorized redirect URIs**.
 
 ### API not enabled — `accessNotConfigured`
 

--- a/README.md
+++ b/README.md
@@ -381,6 +381,9 @@ All variables are optional. See [`.env.example`](.env.example) for a copy-paste 
 | `GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE` | Path to OAuth credentials JSON (user or service account) |
 | `GOOGLE_WORKSPACE_CLI_CLIENT_ID` | OAuth client ID (alternative to `client_secret.json`) |
 | `GOOGLE_WORKSPACE_CLI_CLIENT_SECRET` | OAuth client secret (paired with `CLIENT_ID`) |
+| `GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI` | Override the OAuth `redirect_uri` (e.g. route through an external redirector) |
+| `GOOGLE_WORKSPACE_CLI_OAUTH_STATE` | Opaque OAuth `state` value passed through to the auth URL |
+| `GOOGLE_WORKSPACE_CLI_OAUTH_PORT` | Pin the local OAuth callback port (default: random) |
 | `GOOGLE_WORKSPACE_CLI_CONFIG_DIR` | Override config directory (default: `~/.config/gws`) |
 | `GOOGLE_WORKSPACE_CLI_SANITIZE_TEMPLATE` | Default Model Armor template |
 | `GOOGLE_WORKSPACE_CLI_SANITIZE_MODE` | `warn` (default) or `block` |

--- a/crates/google-workspace-cli/src/auth.rs
+++ b/crates/google-workspace-cli/src/auth.rs
@@ -436,46 +436,9 @@ async fn load_credentials_inner(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::EnvVarGuard;
     use std::io::Write;
     use tempfile::NamedTempFile;
-
-    /// RAII guard that saves the current value of an environment variable and
-    /// restores it when dropped. This ensures cleanup even if a test panics.
-    struct EnvVarGuard {
-        name: String,
-        original: Option<std::ffi::OsString>,
-    }
-
-    impl EnvVarGuard {
-        /// Save the current value of `name`, then set it to `value`.
-        fn set(name: &str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-            let original = std::env::var_os(name);
-            std::env::set_var(name, value);
-            Self {
-                name: name.to_string(),
-                original,
-            }
-        }
-
-        /// Save the current value of `name`, then remove it.
-        fn remove(name: &str) -> Self {
-            let original = std::env::var_os(name);
-            std::env::remove_var(name);
-            Self {
-                name: name.to_string(),
-                original,
-            }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            match &self.original {
-                Some(v) => std::env::set_var(&self.name, v),
-                None => std::env::remove_var(&self.name),
-            }
-        }
-    }
 
     fn clear_proxy_env() -> Vec<EnvVarGuard> {
         PROXY_ENV_VARS

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -98,44 +98,19 @@ fn build_proxy_auth_url(
     url
 }
 
-/// Env var overriding the redirect_uri Google sends the browser to after
-/// auth. Defaults to `http://localhost:{port}`. Set this to route through an
-/// external OAuth redirector (e.g. for a remote dev environment where the
-/// browser can't reach the CLI's local callback server directly).
+// Env vars for customizing the OAuth login callback (see `gws --help`).
 const ENV_OAUTH_REDIRECT_URI: &str = "GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI";
-/// Env var providing a raw `state` value to attach to the auth URL. gws
-/// treats it as an opaque string — whatever encodes the real callback target
-/// (e.g. for an external redirector to decode) is entirely up to whoever
-/// sets this.
 const ENV_OAUTH_STATE: &str = "GOOGLE_WORKSPACE_CLI_OAUTH_STATE";
-/// Env var pinning the local callback server to a fixed port instead of an
-/// OS-assigned ephemeral one, so external tooling can know the port in
-/// advance (e.g. to embed it in `GOOGLE_WORKSPACE_CLI_OAUTH_STATE`).
 const ENV_OAUTH_PORT: &str = "GOOGLE_WORKSPACE_CLI_OAUTH_PORT";
 
-/// Read an env var, treating an empty value the same as unset — matching the
-/// convention `crate::auth::has_proxy_env` uses, so `export VAR=` doesn't
-/// silently count as "set".
-fn env_var_nonempty(key: &str) -> Option<String> {
+fn get_non_empty_env_var(key: &str) -> Option<String> {
     std::env::var(key).ok().filter(|v| !v.is_empty())
 }
 
-/// True if any of the OAuth redirect override env vars are set, meaning the
-/// caller wants control over where/how the browser gets redirected.
-fn has_oauth_redirect_override() -> bool {
+fn has_oauth_callback_override() -> bool {
     [ENV_OAUTH_REDIRECT_URI, ENV_OAUTH_STATE, ENV_OAUTH_PORT]
         .iter()
-        .any(|key| env_var_nonempty(key).is_some())
-}
-
-/// Resolves the redirect_uri Google should send the browser to, and the
-/// `state` value (if any) to attach to the auth URL — both overridable via
-/// env vars so external tooling can route the callback anywhere it needs to.
-fn resolve_redirect_target(port: u16) -> (String, Option<String>) {
-    let redirect_uri = env_var_nonempty(ENV_OAUTH_REDIRECT_URI)
-        .unwrap_or_else(|| format!("http://localhost:{port}"));
-    let state = env_var_nonempty(ENV_OAUTH_STATE);
-    (redirect_uri, state)
+        .any(|key| get_non_empty_env_var(key).is_some())
 }
 
 fn extract_authorization_code(request_line: &str) -> Result<String, GwsError> {
@@ -164,29 +139,36 @@ fn extract_authorization_code(request_line: &str) -> Result<String, GwsError> {
         .ok_or_else(|| GwsError::Auth("No authorization code in callback".to_string()))
 }
 
+fn oauth_redirect_uri(port: u16) -> String {
+    get_non_empty_env_var(ENV_OAUTH_REDIRECT_URI)
+        .unwrap_or_else(|| format!("http://localhost:{port}"))
+}
+
+fn oauth_callback_port() -> Result<u16, GwsError> {
+    get_non_empty_env_var(ENV_OAUTH_PORT)
+        .map(|p| {
+            p.parse::<u16>()
+                .map_err(|e| GwsError::Auth(format!("Invalid {ENV_OAUTH_PORT}: {e}")))
+        })
+        .transpose()
+        .map(|port| port.unwrap_or(0))
+}
+
 /// Perform OAuth login flow with proxy support using reqwest for token exchange
 async fn login_with_proxy_support(
     client_id: &str,
     client_secret: &str,
     scopes: &[String],
 ) -> Result<(String, String), GwsError> {
-    // Start local server to receive OAuth callback. Binds to a fixed port
-    // when GOOGLE_WORKSPACE_CLI_OAUTH_PORT is set, so external tooling can
-    // know the port in advance; otherwise an OS-assigned ephemeral port.
-    let requested_port = env_var_nonempty(ENV_OAUTH_PORT)
-        .map(|p| {
-            p.parse::<u16>()
-                .map_err(|e| GwsError::Auth(format!("Invalid {ENV_OAUTH_PORT}: {e}")))
-        })
-        .transpose()?
-        .unwrap_or(0);
-    let listener = TcpListener::bind(("127.0.0.1", requested_port))
+    // Start local server to receive OAuth callback
+    let listener = TcpListener::bind(("127.0.0.1", oauth_callback_port()?))
         .map_err(|e| GwsError::Auth(format!("Failed to start local server: {e}")))?;
     let port = listener
         .local_addr()
         .map_err(|e| GwsError::Auth(format!("Failed to inspect local server: {e}")))?
         .port();
-    let (redirect_uri, state) = resolve_redirect_target(port);
+    let redirect_uri = oauth_redirect_uri(port);
+    let state = get_non_empty_env_var(ENV_OAUTH_STATE);
 
     let auth_url = build_proxy_auth_url(client_id, &redirect_uri, scopes, state.as_deref());
 
@@ -682,13 +664,10 @@ async fn handle_login_inner(
     std::fs::create_dir_all(&config)
         .map_err(|e| GwsError::Validation(format!("Failed to create config directory: {e}")))?;
 
-    // The proxy-aware flow builds its own auth URL and redirect_uri, so it's
-    // also what's needed whenever a caller wants to override the redirect
-    // target (via GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI/_STATE/_PORT) —
-    // yup-oauth2's InstalledFlowAuthenticator doesn't expose a way to
-    // override its redirect_uri or state per-request.
+    // If proxy or oauth env vars are set, use proxy-aware OAuth flow (reqwest)
+    // Otherwise use yup-oauth2 (faster, but doesn't support proxy)
     let (access_token, refresh_token) =
-        if crate::auth::has_proxy_env() || has_oauth_redirect_override() {
+        if crate::auth::has_proxy_env() || has_oauth_callback_override() {
             login_with_proxy_support(&client_id, &client_secret, &scopes).await?
         } else {
             login_with_yup_oauth(&config, &client_id, &client_secret, &scopes).await?
@@ -1790,6 +1769,7 @@ async fn augment_with_dynamic_scopes(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::EnvVarGuard;
 
     /// Helper to run resolve_scopes in tests (async).
     fn run_resolve_scopes(scope_mode: ScopeMode, project_id: Option<&str>) -> Vec<String> {
@@ -2576,105 +2556,43 @@ mod tests {
         let scopes = vec!["openid".to_string()];
         let url = build_proxy_auth_url(
             "client id",
-            "https://oauth-redirector.example.com",
+            "https://example.com/callback",
             &scopes,
-            Some("eyJ0YXJnZXRfdXJsIjoiZm9vIn0"),
+            Some("eyJub25jZSI6eyJyZWRpcmVjdFVybCI6Ii4uLiJ9fQ"),
         );
 
-        assert!(url.contains("state=eyJ0YXJnZXRfdXJsIjoiZm9vIn0"));
+        assert!(url.contains("state=eyJub25jZSI6eyJyZWRpcmVjdFVybCI6Ii4uLiJ9fQ"));
     }
 
     #[test]
     #[serial_test::serial]
-    fn resolve_redirect_target_defaults_to_localhost() {
-        let keys = [ENV_OAUTH_REDIRECT_URI, ENV_OAUTH_STATE, ENV_OAUTH_PORT];
-        let saved: Vec<Option<String>> = keys.iter().map(|k| std::env::var(k).ok()).collect();
-        for k in keys {
-            std::env::remove_var(k);
-        }
-
-        assert!(!has_oauth_redirect_override());
-        let (redirect_uri, state) = resolve_redirect_target(12345);
-        assert_eq!(redirect_uri, "http://localhost:12345");
-        assert!(state.is_none());
-
-        for (k, v) in keys.iter().zip(saved) {
-            if let Some(v) = v {
-                std::env::set_var(k, v);
-            }
-        }
+    fn oauth_redirect_uri_defaults_to_localhost() {
+        let _uri = EnvVarGuard::remove(ENV_OAUTH_REDIRECT_URI);
+        assert_eq!(oauth_redirect_uri(12345), "http://localhost:12345");
     }
 
     #[test]
     #[serial_test::serial]
-    fn resolve_redirect_target_treats_empty_env_as_unset() {
-        let keys = [ENV_OAUTH_REDIRECT_URI, ENV_OAUTH_STATE, ENV_OAUTH_PORT];
-        let saved: Vec<Option<String>> = keys.iter().map(|k| std::env::var(k).ok()).collect();
-
-        // Empty-but-set vars must behave like unset (matches has_proxy_env).
-        for k in keys {
-            std::env::set_var(k, "");
-        }
-
-        assert!(!has_oauth_redirect_override());
-        let (redirect_uri, state) = resolve_redirect_target(12345);
-        assert_eq!(redirect_uri, "http://localhost:12345");
-        assert!(state.is_none());
-
-        for (k, v) in keys.iter().zip(saved) {
-            match v {
-                Some(v) => std::env::set_var(k, v),
-                None => std::env::remove_var(k),
-            }
-        }
-    }
-
-    #[test]
-    #[serial_test::serial]
-    fn resolve_redirect_target_honors_env_overrides() {
-        let keys = [ENV_OAUTH_REDIRECT_URI, ENV_OAUTH_STATE, ENV_OAUTH_PORT];
-        let saved: Vec<Option<String>> = keys.iter().map(|k| std::env::var(k).ok()).collect();
-
-        std::env::set_var(
-            ENV_OAUTH_REDIRECT_URI,
-            "https://oauth-redirector.example.com",
-        );
-        std::env::set_var(ENV_OAUTH_STATE, "opaque-caller-supplied-state");
-        std::env::remove_var(ENV_OAUTH_PORT);
-
-        assert!(has_oauth_redirect_override());
-        let (redirect_uri, state) = resolve_redirect_target(18323);
-        assert_eq!(redirect_uri, "https://oauth-redirector.example.com");
-        assert_eq!(state, Some("opaque-caller-supplied-state".to_string()));
-
-        for (k, v) in keys.iter().zip(saved) {
-            match v {
-                Some(v) => std::env::set_var(k, v),
-                None => std::env::remove_var(k),
-            }
-        }
+    fn oauth_redirect_uri_honors_override() {
+        let _uri = EnvVarGuard::set(ENV_OAUTH_REDIRECT_URI, "https://example.com/callback");
+        assert_eq!(oauth_redirect_uri(12345), "https://example.com/callback");
     }
 
     #[test]
     fn extract_authorization_code_returns_code() {
         let code =
-            extract_authorization_code("GET /?state=abc&code=4/test-code&scope=openid HTTP/1.1")
+            extract_authorization_code("GET /?state=abc&code=my/test-code1&scope=openid HTTP/1.1")
                 .unwrap();
-        assert_eq!(code, "4/test-code");
+        assert_eq!(code, "my/test-code1");
     }
 
     #[test]
     fn extract_authorization_code_decodes_percent_encoding() {
-        // A redirector hop can re-serialize the query string, percent-encoding
-        // characters (e.g. '/' as %2F, '+' as %2B) that Google's own raw
-        // redirect wouldn't have encoded. The extracted code must match what
-        // Google actually issued, or the token exchange fails with
-        // "invalid_grant: Malformed auth code".
         let code = extract_authorization_code(
-            "GET /?state=abc&code=4%2Ftest%2Bcode&scope=openid HTTP/1.1",
+            "GET /?state=abc&code=my%2Ftest-code1&scope=openid HTTP/1.1",
         )
         .unwrap();
-        assert_eq!(code, "4/test+code");
+        assert_eq!(code, "my/test-code1");
     }
 
     #[test]

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -143,11 +143,16 @@ fn extract_authorization_code(request_line: &str) -> Result<String, GwsError> {
             query.split('&').find_map(|pair| {
                 let mut parts = pair.split('=');
                 if parts.next() == Some("code") {
-                    parts.next().map(|value| value.to_string())
+                    parts.next()
                 } else {
                     None
                 }
             })
+        })
+        .map(|value| {
+            percent_encoding::percent_decode_str(value)
+                .decode_utf8_lossy()
+                .into_owned()
         })
         .ok_or_else(|| GwsError::Auth("No authorization code in callback".to_string()))
 }
@@ -193,7 +198,12 @@ async fn login_with_proxy_support(
         .read_line(&mut request_line)
         .map_err(|e| GwsError::Auth(format!("Failed to read request: {e}")))?;
 
+    eprintln!("Received callback: {}", request_line.trim());
+
     let code = extract_authorization_code(&request_line)?;
+
+    eprintln!("Parsed code: {code}");
+    eprintln!("Using redirect_uri: {redirect_uri}");
 
     // Send success response to browser
     let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n\
@@ -2626,6 +2636,20 @@ mod tests {
             extract_authorization_code("GET /?state=abc&code=4/test-code&scope=openid HTTP/1.1")
                 .unwrap();
         assert_eq!(code, "4/test-code");
+    }
+
+    #[test]
+    fn extract_authorization_code_decodes_percent_encoding() {
+        // A redirector hop can re-serialize the query string, percent-encoding
+        // characters (e.g. '/' as %2F, '+' as %2B) that Google's own raw
+        // redirect wouldn't have encoded. The extracted code must match what
+        // Google actually issued, or the token exchange fails with
+        // "invalid_grant: Malformed auth code".
+        let code = extract_authorization_code(
+            "GET /?state=abc&code=4%2Ftest%2Bcode&scope=openid HTTP/1.1",
+        )
+        .unwrap();
+        assert_eq!(code, "4/test+code");
     }
 
     #[test]

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -113,21 +113,28 @@ const ENV_OAUTH_STATE: &str = "GOOGLE_WORKSPACE_CLI_OAUTH_STATE";
 /// advance (e.g. to embed it in `GOOGLE_WORKSPACE_CLI_OAUTH_STATE`).
 const ENV_OAUTH_PORT: &str = "GOOGLE_WORKSPACE_CLI_OAUTH_PORT";
 
+/// Read an env var, treating an empty value the same as unset — matching the
+/// convention `crate::auth::has_proxy_env` uses, so `export VAR=` doesn't
+/// silently count as "set".
+fn env_var_nonempty(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|v| !v.is_empty())
+}
+
 /// True if any of the OAuth redirect override env vars are set, meaning the
 /// caller wants control over where/how the browser gets redirected.
 fn has_oauth_redirect_override() -> bool {
-    std::env::var(ENV_OAUTH_REDIRECT_URI).is_ok()
-        || std::env::var(ENV_OAUTH_STATE).is_ok()
-        || std::env::var(ENV_OAUTH_PORT).is_ok()
+    [ENV_OAUTH_REDIRECT_URI, ENV_OAUTH_STATE, ENV_OAUTH_PORT]
+        .iter()
+        .any(|key| env_var_nonempty(key).is_some())
 }
 
 /// Resolves the redirect_uri Google should send the browser to, and the
 /// `state` value (if any) to attach to the auth URL — both overridable via
 /// env vars so external tooling can route the callback anywhere it needs to.
 fn resolve_redirect_target(port: u16) -> (String, Option<String>) {
-    let redirect_uri = std::env::var(ENV_OAUTH_REDIRECT_URI)
-        .unwrap_or_else(|_| format!("http://localhost:{port}"));
-    let state = std::env::var(ENV_OAUTH_STATE).ok();
+    let redirect_uri =
+        env_var_nonempty(ENV_OAUTH_REDIRECT_URI).unwrap_or_else(|| format!("http://localhost:{port}"));
+    let state = env_var_nonempty(ENV_OAUTH_STATE);
     (redirect_uri, state)
 }
 
@@ -166,8 +173,7 @@ async fn login_with_proxy_support(
     // Start local server to receive OAuth callback. Binds to a fixed port
     // when GOOGLE_WORKSPACE_CLI_OAUTH_PORT is set, so external tooling can
     // know the port in advance; otherwise an OS-assigned ephemeral port.
-    let requested_port = std::env::var(ENV_OAUTH_PORT)
-        .ok()
+    let requested_port = env_var_nonempty(ENV_OAUTH_PORT)
         .map(|p| {
             p.parse::<u16>()
                 .map_err(|e| GwsError::Auth(format!("Invalid {ENV_OAUTH_PORT}: {e}")))
@@ -2595,6 +2601,30 @@ mod tests {
         for (k, v) in keys.iter().zip(saved) {
             if let Some(v) = v {
                 std::env::set_var(k, v);
+            }
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_redirect_target_treats_empty_env_as_unset() {
+        let keys = [ENV_OAUTH_REDIRECT_URI, ENV_OAUTH_STATE, ENV_OAUTH_PORT];
+        let saved: Vec<Option<String>> = keys.iter().map(|k| std::env::var(k).ok()).collect();
+
+        // Empty-but-set vars must behave like unset (matches has_proxy_env).
+        for k in keys {
+            std::env::set_var(k, "");
+        }
+
+        assert!(!has_oauth_redirect_override());
+        let (redirect_uri, state) = resolve_redirect_target(12345);
+        assert_eq!(redirect_uri, "http://localhost:12345");
+        assert!(state.is_none());
+
+        for (k, v) in keys.iter().zip(saved) {
+            match v {
+                Some(v) => std::env::set_var(k, v),
+                None => std::env::remove_var(k),
             }
         }
     }

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashSet;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 
@@ -164,6 +164,24 @@ fn oauth_callback_port() -> Result<u16, GwsError> {
         .map(|port| port.unwrap_or(0))
 }
 
+const MAX_CALLBACK_REQUEST_BYTES: u64 = 8 * 1024;
+
+fn read_request_line<R: Read>(stream: R) -> Result<String, GwsError> {
+    let mut reader = BufReader::new(stream.take(MAX_CALLBACK_REQUEST_BYTES));
+    let mut request_line = String::new();
+    let read = reader
+        .read_line(&mut request_line)
+        .map_err(|e| GwsError::Auth(format!("Failed to read request: {e}")))?;
+
+    if read as u64 == MAX_CALLBACK_REQUEST_BYTES && !request_line.ends_with('\n') {
+        return Err(GwsError::Auth(format!(
+            "OAuth callback request line exceeded {MAX_CALLBACK_REQUEST_BYTES} bytes. \
+             The request was rejected without being processed"
+        )));
+    }
+    Ok(request_line)
+}
+
 /// Perform OAuth login flow with proxy support using reqwest for token exchange
 async fn login_with_proxy_support(
     client_id: &str,
@@ -190,11 +208,7 @@ async fn login_with_proxy_support(
         .accept()
         .map_err(|e| GwsError::Auth(format!("Failed to accept connection: {e}")))?;
 
-    let mut reader = BufReader::new(&stream);
-    let mut request_line = String::new();
-    reader
-        .read_line(&mut request_line)
-        .map_err(|e| GwsError::Auth(format!("Failed to read request: {e}")))?;
+    let request_line = read_request_line(&stream)?;
 
     // Reject a forged callback before doing anything with the code
     verify_callback_state(&request_line)?;
@@ -2643,6 +2657,20 @@ mod tests {
     fn query_param_preserves_equals_in_value() {
         let line = "GET /?state=YQ==&code=x HTTP/1.1";
         assert_eq!(query_param(line, "state").as_deref(), Some("YQ=="));
+    }
+
+    #[test]
+    fn read_request_line_reads_normal_line() {
+        let input = b"GET /?code=4/x HTTP/1.1\r\n";
+        let line = read_request_line(&input[..]).unwrap();
+        assert!(line.starts_with("GET /?code=4/x"));
+    }
+
+    #[test]
+    fn read_request_line_is_bounded_without_newline() {
+        let huge = vec![b'a'; MAX_CALLBACK_REQUEST_BYTES as usize * 4];
+        let err = read_request_line(&huge[..]).unwrap_err();
+        assert!(err.to_string().contains("exceeded"));
     }
 
     #[test]

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -198,12 +198,7 @@ async fn login_with_proxy_support(
         .read_line(&mut request_line)
         .map_err(|e| GwsError::Auth(format!("Failed to read request: {e}")))?;
 
-    eprintln!("Received callback: {}", request_line.trim());
-
     let code = extract_authorization_code(&request_line)?;
-
-    eprintln!("Parsed code: {code}");
-    eprintln!("Using redirect_uri: {redirect_uri}");
 
     // Send success response to browser
     let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n\

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -72,9 +72,14 @@ async fn exchange_code_with_reqwest(
         .map_err(|e| GwsError::Auth(format!("Failed to parse token response: {e}")))
 }
 
-fn build_proxy_auth_url(client_id: &str, redirect_uri: &str, scopes: &[String]) -> String {
+fn build_proxy_auth_url(
+    client_id: &str,
+    redirect_uri: &str,
+    scopes: &[String],
+    state: Option<&str>,
+) -> String {
     let scopes_str = scopes.join(" ");
-    format!(
+    let mut url = format!(
         "https://accounts.google.com/o/oauth2/auth?\
          scope={}&\
          access_type=offline&\
@@ -85,7 +90,45 @@ fn build_proxy_auth_url(client_id: &str, redirect_uri: &str, scopes: &[String]) 
         urlencoding(&scopes_str),
         urlencoding(redirect_uri),
         urlencoding(client_id)
-    )
+    );
+    if let Some(state) = state {
+        url.push_str("&state=");
+        url.push_str(&urlencoding(state));
+    }
+    url
+}
+
+/// Env var overriding the redirect_uri Google sends the browser to after
+/// auth. Defaults to `http://localhost:{port}`. Set this to route through an
+/// external OAuth redirector (e.g. for a remote dev environment where the
+/// browser can't reach the CLI's local callback server directly).
+const ENV_OAUTH_REDIRECT_URI: &str = "GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI";
+/// Env var providing a raw `state` value to attach to the auth URL. gws
+/// treats it as an opaque string — whatever encodes the real callback target
+/// (e.g. for an external redirector to decode) is entirely up to whoever
+/// sets this.
+const ENV_OAUTH_STATE: &str = "GOOGLE_WORKSPACE_CLI_OAUTH_STATE";
+/// Env var pinning the local callback server to a fixed port instead of an
+/// OS-assigned ephemeral one, so external tooling can know the port in
+/// advance (e.g. to embed it in `GOOGLE_WORKSPACE_CLI_OAUTH_STATE`).
+const ENV_OAUTH_PORT: &str = "GOOGLE_WORKSPACE_CLI_OAUTH_PORT";
+
+/// True if any of the OAuth redirect override env vars are set, meaning the
+/// caller wants control over where/how the browser gets redirected.
+fn has_oauth_redirect_override() -> bool {
+    std::env::var(ENV_OAUTH_REDIRECT_URI).is_ok()
+        || std::env::var(ENV_OAUTH_STATE).is_ok()
+        || std::env::var(ENV_OAUTH_PORT).is_ok()
+}
+
+/// Resolves the redirect_uri Google should send the browser to, and the
+/// `state` value (if any) to attach to the auth URL — both overridable via
+/// env vars so external tooling can route the callback anywhere it needs to.
+fn resolve_redirect_target(port: u16) -> (String, Option<String>) {
+    let redirect_uri = std::env::var(ENV_OAUTH_REDIRECT_URI)
+        .unwrap_or_else(|_| format!("http://localhost:{port}"));
+    let state = std::env::var(ENV_OAUTH_STATE).ok();
+    (redirect_uri, state)
 }
 
 fn extract_authorization_code(request_line: &str) -> Result<String, GwsError> {
@@ -115,16 +158,26 @@ async fn login_with_proxy_support(
     client_secret: &str,
     scopes: &[String],
 ) -> Result<(String, String), GwsError> {
-    // Start local server to receive OAuth callback
-    let listener = TcpListener::bind("127.0.0.1:0")
+    // Start local server to receive OAuth callback. Binds to a fixed port
+    // when GOOGLE_WORKSPACE_CLI_OAUTH_PORT is set, so external tooling can
+    // know the port in advance; otherwise an OS-assigned ephemeral port.
+    let requested_port = std::env::var(ENV_OAUTH_PORT)
+        .ok()
+        .map(|p| {
+            p.parse::<u16>()
+                .map_err(|e| GwsError::Auth(format!("Invalid {ENV_OAUTH_PORT}: {e}")))
+        })
+        .transpose()?
+        .unwrap_or(0);
+    let listener = TcpListener::bind(("127.0.0.1", requested_port))
         .map_err(|e| GwsError::Auth(format!("Failed to start local server: {e}")))?;
     let port = listener
         .local_addr()
         .map_err(|e| GwsError::Auth(format!("Failed to inspect local server: {e}")))?
         .port();
-    let redirect_uri = format!("http://localhost:{}", port);
+    let (redirect_uri, state) = resolve_redirect_target(port);
 
-    let auth_url = build_proxy_auth_url(client_id, &redirect_uri, scopes);
+    let auth_url = build_proxy_auth_url(client_id, &redirect_uri, scopes, state.as_deref());
 
     println!("Open this URL in your browser to authenticate:\n");
     println!("  {}\n", auth_url);
@@ -618,13 +671,17 @@ async fn handle_login_inner(
     std::fs::create_dir_all(&config)
         .map_err(|e| GwsError::Validation(format!("Failed to create config directory: {e}")))?;
 
-    // If proxy env vars are set, use proxy-aware OAuth flow (reqwest)
-    // Otherwise use yup-oauth2 (faster, but doesn't support proxy)
-    let (access_token, refresh_token) = if crate::auth::has_proxy_env() {
-        login_with_proxy_support(&client_id, &client_secret, &scopes).await?
-    } else {
-        login_with_yup_oauth(&config, &client_id, &client_secret, &scopes).await?
-    };
+    // The proxy-aware flow builds its own auth URL and redirect_uri, so it's
+    // also what's needed whenever a caller wants to override the redirect
+    // target (via GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI/_STATE/_PORT) —
+    // yup-oauth2's InstalledFlowAuthenticator doesn't expose a way to
+    // override its redirect_uri or state per-request.
+    let (access_token, refresh_token) =
+        if crate::auth::has_proxy_env() || has_oauth_redirect_override() {
+            login_with_proxy_support(&client_id, &client_secret, &scopes).await?
+        } else {
+            login_with_yup_oauth(&config, &client_id, &client_secret, &scopes).await?
+        };
 
     // Build credentials in the standard authorized_user format
     let creds_json = json!({
@@ -2487,7 +2544,12 @@ mod tests {
             "https://www.googleapis.com/auth/drive".to_string(),
             "openid".to_string(),
         ];
-        let url = build_proxy_auth_url("client id", "http://localhost:8080/callback path", &scopes);
+        let url = build_proxy_auth_url(
+            "client id",
+            "http://localhost:8080/callback path",
+            &scopes,
+            None,
+        );
 
         assert!(url.contains("client_id=client%20id"));
         assert!(url.contains("redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fcallback%20path"));
@@ -2495,6 +2557,67 @@ mod tests {
             "scope={}",
             urlencoding("https://www.googleapis.com/auth/drive openid")
         )));
+        assert!(!url.contains("state="));
+    }
+
+    #[test]
+    fn build_proxy_auth_url_includes_state_when_present() {
+        let scopes = vec!["openid".to_string()];
+        let url = build_proxy_auth_url(
+            "client id",
+            "https://oauth-redirector.example.com",
+            &scopes,
+            Some("eyJ0YXJnZXRfdXJsIjoiZm9vIn0"),
+        );
+
+        assert!(url.contains("state=eyJ0YXJnZXRfdXJsIjoiZm9vIn0"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_redirect_target_defaults_to_localhost() {
+        let keys = [ENV_OAUTH_REDIRECT_URI, ENV_OAUTH_STATE, ENV_OAUTH_PORT];
+        let saved: Vec<Option<String>> = keys.iter().map(|k| std::env::var(k).ok()).collect();
+        for k in keys {
+            std::env::remove_var(k);
+        }
+
+        assert!(!has_oauth_redirect_override());
+        let (redirect_uri, state) = resolve_redirect_target(12345);
+        assert_eq!(redirect_uri, "http://localhost:12345");
+        assert!(state.is_none());
+
+        for (k, v) in keys.iter().zip(saved) {
+            if let Some(v) = v {
+                std::env::set_var(k, v);
+            }
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_redirect_target_honors_env_overrides() {
+        let keys = [ENV_OAUTH_REDIRECT_URI, ENV_OAUTH_STATE, ENV_OAUTH_PORT];
+        let saved: Vec<Option<String>> = keys.iter().map(|k| std::env::var(k).ok()).collect();
+
+        std::env::set_var(
+            ENV_OAUTH_REDIRECT_URI,
+            "https://oauth-redirector.example.com",
+        );
+        std::env::set_var(ENV_OAUTH_STATE, "opaque-caller-supplied-state");
+        std::env::remove_var(ENV_OAUTH_PORT);
+
+        assert!(has_oauth_redirect_override());
+        let (redirect_uri, state) = resolve_redirect_target(18323);
+        assert_eq!(redirect_uri, "https://oauth-redirector.example.com");
+        assert_eq!(state, Some("opaque-caller-supplied-state".to_string()));
+
+        for (k, v) in keys.iter().zip(saved) {
+            match v {
+                Some(v) => std::env::set_var(k, v),
+                None => std::env::remove_var(k),
+            }
+        }
     }
 
     #[test]

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -113,30 +113,40 @@ fn has_oauth_callback_override() -> bool {
         .any(|key| get_non_empty_env_var(key).is_some())
 }
 
+fn query_param(request_line: &str, name: &str) -> Option<String> {
+    let query = request_line.split_whitespace().nth(1)?.split('?').nth(1)?;
+    query.split('&').find_map(|pair| {
+        let mut parts = pair.splitn(2, '=');
+        if parts.next() == Some(name) {
+            parts.next().map(|value| {
+                percent_encoding::percent_decode_str(value)
+                    .decode_utf8_lossy()
+                    .into_owned()
+            })
+        } else {
+            None
+        }
+    })
+}
+
 fn extract_authorization_code(request_line: &str) -> Result<String, GwsError> {
-    let path = request_line
+    request_line
         .split_whitespace()
         .nth(1)
         .ok_or_else(|| GwsError::Auth("Invalid HTTP request".to_string()))?;
-
-    path.split('?')
-        .nth(1)
-        .and_then(|query| {
-            query.split('&').find_map(|pair| {
-                let mut parts = pair.split('=');
-                if parts.next() == Some("code") {
-                    parts.next()
-                } else {
-                    None
-                }
-            })
-        })
-        .map(|value| {
-            percent_encoding::percent_decode_str(value)
-                .decode_utf8_lossy()
-                .into_owned()
-        })
+    query_param(request_line, "code")
         .ok_or_else(|| GwsError::Auth("No authorization code in callback".to_string()))
+}
+
+fn verify_callback_state(request_line: &str) -> Result<(), GwsError> {
+    let Some(expected) = get_non_empty_env_var(ENV_OAUTH_STATE) else {
+        return Ok(());
+    };
+    if query_param(request_line, "state").as_deref() == Some(expected.as_str()) {
+        Ok(())
+    } else {
+        Err(GwsError::Auth("OAuth state mismatch".to_string()))
+    }
 }
 
 fn oauth_redirect_uri(port: u16) -> String {
@@ -186,6 +196,8 @@ async fn login_with_proxy_support(
         .read_line(&mut request_line)
         .map_err(|e| GwsError::Auth(format!("Failed to read request: {e}")))?;
 
+    // Reject a forged callback before doing anything with the code
+    verify_callback_state(&request_line)?;
     let code = extract_authorization_code(&request_line)?;
 
     // Send success response to browser
@@ -2588,10 +2600,9 @@ mod tests {
 
     #[test]
     fn extract_authorization_code_decodes_percent_encoding() {
-        let code = extract_authorization_code(
-            "GET /?state=abc&code=4%2Ftest-code&scope=openid HTTP/1.1",
-        )
-        .unwrap();
+        let code =
+            extract_authorization_code("GET /?state=abc&code=4%2Ftest-code&scope=openid HTTP/1.1")
+                .unwrap();
         assert_eq!(code, "4/test-code");
     }
 
@@ -2599,6 +2610,69 @@ mod tests {
     fn extract_authorization_code_rejects_missing_code() {
         let err = extract_authorization_code("GET /?state=abc HTTP/1.1").unwrap_err();
         assert!(err.to_string().contains("No authorization code"));
+    }
+
+    #[test]
+    fn extract_authorization_code_rejects_malformed_request() {
+        let err = extract_authorization_code("GARBAGE").unwrap_err();
+        assert!(err.to_string().contains("Invalid HTTP request"));
+    }
+
+    #[test]
+    fn query_param_returns_decoded_value() {
+        let line = "GET /?state=abc&code=4%2Ftest-code&scope=openid HTTP/1.1";
+        assert_eq!(query_param(line, "code").as_deref(), Some("4/test-code"));
+        assert_eq!(query_param(line, "state").as_deref(), Some("abc"));
+        assert_eq!(query_param(line, "scope").as_deref(), Some("openid"));
+    }
+
+    #[test]
+    fn query_param_absent_or_no_query_is_none() {
+        assert_eq!(query_param("GET /?a=1 HTTP/1.1", "code"), None);
+        assert_eq!(query_param("GET / HTTP/1.1", "code"), None);
+        assert_eq!(query_param("GARBAGE", "code"), None);
+    }
+
+    #[test]
+    fn query_param_matches_full_name_not_prefix() {
+        let line = "GET /?abcd=no&abc=yes HTTP/1.1";
+        assert_eq!(query_param(line, "abc").as_deref(), Some("yes"));
+    }
+
+    #[test]
+    fn query_param_preserves_equals_in_value() {
+        let line = "GET /?state=YQ==&code=x HTTP/1.1";
+        assert_eq!(query_param(line, "state").as_deref(), Some("YQ=="));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn verify_callback_state_skips_when_no_state_configured() {
+        let _state = EnvVarGuard::remove(ENV_OAUTH_STATE);
+
+        verify_callback_state("GET /?code=4/test-code HTTP/1.1").unwrap();
+        verify_callback_state("GET /?state=whatever&code=4/test-code HTTP/1.1").unwrap();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn verify_callback_state_accepts_matching_state() {
+        let _state = EnvVarGuard::set(ENV_OAUTH_STATE, "secure-state");
+
+        verify_callback_state("GET /?state=secure-state&code=4/test-code HTTP/1.1").unwrap();
+        verify_callback_state("GET /?state=secure%2Dstate&code=4/x HTTP/1.1").unwrap();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn verify_callback_state_rejects_mismatched_or_missing_state() {
+        let _state = EnvVarGuard::set(ENV_OAUTH_STATE, "secure-state");
+
+        let err = verify_callback_state("GET /?state=wrong&code=4/test-code HTTP/1.1").unwrap_err();
+        assert!(err.to_string().contains("state mismatch"));
+
+        let err = verify_callback_state("GET /?code=4/test-code HTTP/1.1").unwrap_err();
+        assert!(err.to_string().contains("state mismatch"));
     }
 
     #[test]

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -132,8 +132,8 @@ fn has_oauth_redirect_override() -> bool {
 /// `state` value (if any) to attach to the auth URL — both overridable via
 /// env vars so external tooling can route the callback anywhere it needs to.
 fn resolve_redirect_target(port: u16) -> (String, Option<String>) {
-    let redirect_uri =
-        env_var_nonempty(ENV_OAUTH_REDIRECT_URI).unwrap_or_else(|| format!("http://localhost:{port}"));
+    let redirect_uri = env_var_nonempty(ENV_OAUTH_REDIRECT_URI)
+        .unwrap_or_else(|| format!("http://localhost:{port}"));
     let state = env_var_nonempty(ENV_OAUTH_STATE);
     (redirect_uri, state)
 }

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -2581,18 +2581,18 @@ mod tests {
     #[test]
     fn extract_authorization_code_returns_code() {
         let code =
-            extract_authorization_code("GET /?state=abc&code=my/test-code1&scope=openid HTTP/1.1")
+            extract_authorization_code("GET /?state=abc&code=4/test-code&scope=openid HTTP/1.1")
                 .unwrap();
-        assert_eq!(code, "my/test-code1");
+        assert_eq!(code, "4/test-code");
     }
 
     #[test]
     fn extract_authorization_code_decodes_percent_encoding() {
         let code = extract_authorization_code(
-            "GET /?state=abc&code=my%2Ftest-code1&scope=openid HTTP/1.1",
+            "GET /?state=abc&code=4%2Ftest-code&scope=openid HTTP/1.1",
         )
         .unwrap();
-        assert_eq!(code, "my/test-code1");
+        assert_eq!(code, "4/test-code");
     }
 
     #[test]

--- a/crates/google-workspace-cli/src/main.rs
+++ b/crates/google-workspace-cli/src/main.rs
@@ -38,6 +38,8 @@ mod schema;
 mod services;
 mod setup;
 mod setup_tui;
+#[cfg(test)]
+mod test_support;
 mod text;
 mod timezone;
 mod token_storage;
@@ -482,10 +484,10 @@ fn print_usage() {
         "    GOOGLE_WORKSPACE_CLI_CLIENT_SECRET       OAuth client secret (for gws auth login)"
     );
     println!(
-        "    GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI  Override OAuth redirect_uri (e.g. an external redirector)"
+        "    GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI  Override OAuth redirect URI (for remote-host logins)"
     );
     println!(
-        "    GOOGLE_WORKSPACE_CLI_OAUTH_STATE         Opaque OAuth state value passed through to the auth URL"
+        "    GOOGLE_WORKSPACE_CLI_OAUTH_STATE         OAuth state value, passed through to the auth URL"
     );
     println!(
         "    GOOGLE_WORKSPACE_CLI_OAUTH_PORT          Pin the local OAuth callback port (default: random)"

--- a/crates/google-workspace-cli/src/main.rs
+++ b/crates/google-workspace-cli/src/main.rs
@@ -487,7 +487,7 @@ fn print_usage() {
         "    GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI  Override OAuth redirect URI (for remote-host logins)"
     );
     println!(
-        "    GOOGLE_WORKSPACE_CLI_OAUTH_STATE         OAuth state value, passed through to the auth URL"
+        "    GOOGLE_WORKSPACE_CLI_OAUTH_STATE         OAuth state value passed to the server and verified on the callback"
     );
     println!(
         "    GOOGLE_WORKSPACE_CLI_OAUTH_PORT          Pin the local OAuth callback port (default: random)"

--- a/crates/google-workspace-cli/src/main.rs
+++ b/crates/google-workspace-cli/src/main.rs
@@ -482,6 +482,15 @@ fn print_usage() {
         "    GOOGLE_WORKSPACE_CLI_CLIENT_SECRET       OAuth client secret (for gws auth login)"
     );
     println!(
+        "    GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI  Override OAuth redirect_uri (e.g. an external redirector)"
+    );
+    println!(
+        "    GOOGLE_WORKSPACE_CLI_OAUTH_STATE         Opaque OAuth state value passed through to the auth URL"
+    );
+    println!(
+        "    GOOGLE_WORKSPACE_CLI_OAUTH_PORT          Pin the local OAuth callback port (default: random)"
+    );
+    println!(
         "    GOOGLE_WORKSPACE_CLI_CONFIG_DIR          Override config directory (default: ~/.config/gws)"
     );
     println!(

--- a/crates/google-workspace-cli/src/test_support.rs
+++ b/crates/google-workspace-cli/src/test_support.rs
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared test-only helpers.
+
+/// Saves an env var's current value on construction and restores it (or unsets
+/// it) on drop — including on panic. Pair with `#[serial_test::serial]`, since
+/// the environment is process-global.
+pub(crate) struct EnvVarGuard {
+    name: String,
+    original: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    /// Save the current value of `name`, then set it to `value`.
+    pub(crate) fn set(name: &str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let original = std::env::var_os(name);
+        std::env::set_var(name, value);
+        Self {
+            name: name.to_string(),
+            original,
+        }
+    }
+
+    /// Save the current value of `name`, then remove it.
+    pub(crate) fn remove(name: &str) -> Self {
+        let original = std::env::var_os(name);
+        std::env::remove_var(name);
+        Self {
+            name: name.to_string(),
+            original,
+        }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.original {
+            Some(v) => std::env::set_var(&self.name, v),
+            None => std::env::remove_var(&self.name),
+        }
+    }
+}


### PR DESCRIPTION
## Description

`gws auth login`'s flow assumes the browser can reach the CLI's callback server on `localhost`.

When the CLI runs on a remote host (e.g. a cloud development environment), the server is not reachable from the developer's laptop browser, so the OAuth callback has to be redirected to an address other than the laptop's `localhost`.

This Pull Request adds three optional environment variables that let the caller customize the OAuth flow:

- `GOOGLE_WORKSPACE_CLI_OAUTH_REDIRECT_URI` - sets the redirect URI sent to Google.
- `GOOGLE_WORKSPACE_CLI_OAUTH_STATE` - a `state` value passed to the authorization URL (see [use cases](https://auth0.com/docs/secure/attack-protection/state-parameters)).
- `GOOGLE_WORKSPACE_CLI_OAUTH_PORT` - sets the port of the local callback listener.

## Implementation notes

- The authorisation code could be percent-encoded on the way between Google's server and the remote host. This will lead to `invalid_grant: Malformed auth code`, unless the code is decoded by `gws`.
- When `GOOGLE_WORKSPACE_CLI_OAUTH_STATE` is set, the `state` returned on the callback is verified against it. A missing or mismatched value is rejected to guard against forged (CSRF) callbacks.
- The callback server bounds how much it reads from the request line (8 KiB), so a client that never sends a newline cannot exhaust memory (DoS) - relevant now that the port may be reachable from remote networks.
- Moved helper for testing with environment variables from `auth.rs` to `test_support.rs`.

## Checklist

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.
