### PR TITLE
feat(auth): open the OAuth URL in the default browser

### DIFF
--- a/.changeset/auth-login-open-browser.md
+++ b/.changeset/auth-login-open-browser.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": minor
+---
+
+Open OAuth login URLs in the browser with a copy-paste fallback

--- a/crates/google-workspace-cli/src/auth.rs
+++ b/crates/google-workspace-cli/src/auth.rs
@@ -763,8 +763,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let enc_path = dir.path().join("credentials.enc");
 
-        // Isolate global config dir to prevent races with other tests
-        std::env::set_var("GOOGLE_WORKSPACE_CLI_CONFIG_DIR", dir.path());
+        // Isolate global config dir to prevent races with other tests. The
+        // guard restores the variable on drop; a bare set_var leaked it into
+        // every later test, and config_dir_returns_gws_subdir then read a
+        // dropped tempdir path instead of the real default.
+        let _config_dir = EnvVarGuard::set("GOOGLE_WORKSPACE_CLI_CONFIG_DIR", dir.path());
 
         // Encrypt and write
         let encrypted = crate::credential_store::encrypt(json.as_bytes()).unwrap();

--- a/crates/google-workspace-cli/src/auth_commands.rs
+++ b/crates/google-workspace-cli/src/auth_commands.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use std::collections::HashSet;
+use std::ffi::OsString;
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 use serde::Deserialize;
 use serde_json::json;
@@ -88,6 +90,62 @@ fn build_proxy_auth_url(client_id: &str, redirect_uri: &str, scopes: &[String]) 
     )
 }
 
+fn browser_command(browser: Option<OsString>, os: &str) -> Option<OsString> {
+    browser.or_else(|| match os {
+        "linux" => Some(OsString::from("xdg-open")),
+        "macos" => Some(OsString::from("open")),
+        // `explorer` avoids cmd.exe URL parsing and the EDR-sensitive rundll32 opener.
+        "windows" => Some(OsString::from("explorer")),
+        _ => None,
+    })
+}
+
+fn is_openable_url(url: &str) -> bool {
+    url.starts_with("https://")
+        && !url.chars().any(|c| {
+            c.is_control()
+                || c.is_whitespace()
+                || crate::output::is_dangerous_unicode(c)
+                || matches!(c, '"' | '\'' | '\\' | ';' | '$' | '|' | '`' | '<' | '>')
+        })
+}
+
+/// Attempt to open an OAuth URL without blocking or affecting the login flow.
+///
+/// Returns whether an opener was actually spawned, so the caller only claims
+/// a browser is opening when one is. The child is reaped in a background
+/// thread, so a slow platform opener cannot block the callback server.
+fn try_open_browser(url: &str) -> bool {
+    if !is_openable_url(url) {
+        return false;
+    }
+
+    let Some(program) = browser_command(std::env::var_os("BROWSER"), std::env::consts::OS) else {
+        return false;
+    };
+
+    match Command::new(program)
+        .arg(url)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(mut child) => {
+            // Builder::spawn returns Err instead of panicking when the OS
+            // refuses a thread; the unreaped child then lingers only until
+            // this short-lived CLI exits, and the login is unaffected.
+            let _ = std::thread::Builder::new()
+                .name("gws-browser-reaper".to_string())
+                .spawn(move || {
+                    let _ = child.wait();
+                });
+            true
+        }
+        Err(_) => false,
+    }
+}
+
 fn extract_authorization_code(request_line: &str) -> Result<String, GwsError> {
     let path = request_line
         .split_whitespace()
@@ -126,6 +184,9 @@ async fn login_with_proxy_support(
 
     let auth_url = build_proxy_auth_url(client_id, &redirect_uri, scopes);
 
+    if try_open_browser(&auth_url) {
+        println!("Opening in your browser...");
+    }
     println!("Open this URL in your browser to authenticate:\n");
     println!("  {}\n", auth_url);
 
@@ -565,6 +626,9 @@ impl yup_oauth2::authenticator_delegate::InstalledFlowDelegate for CliFlowDelega
             } else {
                 url.to_string()
             };
+            if try_open_browser(&display_url) {
+                eprintln!("Opening in your browser...");
+            }
             eprintln!("Open this URL in your browser to authenticate:\n");
             eprintln!("  {display_url}\n");
             Ok(String::new())
@@ -2479,6 +2543,68 @@ mod tests {
         };
         let result = extract_scopes_from_doc(&doc, false);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn browser_command_prefers_browser_env() {
+        // $BROWSER is a single command, not a shell line; arguments are not split.
+        let browser = std::ffi::OsString::from("/opt/bin/my-browser");
+
+        let command = browser_command(Some(browser.clone()), "linux");
+
+        assert_eq!(command, Some(browser));
+    }
+
+    #[test]
+    fn browser_command_uses_xdg_open_on_linux() {
+        let command = browser_command(None, "linux");
+
+        assert_eq!(command, Some(std::ffi::OsString::from("xdg-open")));
+    }
+
+    #[test]
+    fn browser_command_uses_open_on_macos() {
+        let command = browser_command(None, "macos");
+
+        assert_eq!(command, Some(std::ffi::OsString::from("open")));
+    }
+
+    #[test]
+    fn browser_command_uses_explorer_on_windows() {
+        let command = browser_command(None, "windows");
+
+        assert_eq!(command, Some(std::ffi::OsString::from("explorer")));
+    }
+
+    #[test]
+    fn browser_command_rejects_unknown_platform() {
+        let command = browser_command(None, "freebsd");
+
+        assert_eq!(command, None);
+    }
+
+    #[test]
+    fn openable_url_accepts_https_url() {
+        assert!(is_openable_url(
+            "https://accounts.google.com/o/oauth2/auth?scope=openid"
+        ));
+    }
+
+    #[test]
+    fn openable_url_rejects_control_whitespace_and_dangerous_unicode() {
+        assert!(!is_openable_url("https://example.com/with space"));
+        assert!(!is_openable_url("https://example.com/with\nnewline"));
+        assert!(!is_openable_url("https://example.com/\u{202E}override"));
+        assert!(!is_openable_url("https://example.com/zero\u{200B}width"));
+    }
+
+    #[test]
+    fn openable_url_rejects_quotes_backslashes_and_shell_characters() {
+        assert!(!is_openable_url("https://example.com/\""));
+        assert!(!is_openable_url("https://example.com/'"));
+        assert!(!is_openable_url("https://example.com/\\"));
+        assert!(!is_openable_url("https://example.com/;evil"));
+        assert!(!is_openable_url("https://example.com/$(evil)"));
     }
 
     #[test]

--- a/crates/google-workspace-cli/src/helpers/script.rs
+++ b/crates/google-workspace-cli/src/helpers/script.rs
@@ -169,13 +169,7 @@ fn process_file(path: &Path) -> Result<Option<serde_json::Value>, GwsError> {
             filename.trim_end_matches(".js").trim_end_matches(".gs"),
         ),
         "html" => ("HTML", filename.trim_end_matches(".html")),
-        "json" => {
-            if filename == "appsscript.json" {
-                ("JSON", "appsscript")
-            } else {
-                return Ok(None);
-            }
-        }
+        "json" if filename == "appsscript.json" => ("JSON", "appsscript"),
         _ => return Ok(None),
     };
 


### PR DESCRIPTION
## Description

This supersedes #875, which went stale before its review feedback was addressed.

`gws auth login` currently prints the OAuth URL and waits — on a remote or headless machine that means manually copying the URL *and* manually forwarding the ephemeral localhost callback port. This PR makes both login flows attempt to open the URL in a browser, keeping the printed URL as the copy-paste fallback:

- Honors `$BROWSER` first when set (treated as a single command, not a shell line).
- Otherwise `xdg-open` on Linux, `open` on macOS, `explorer` on Windows.
- The opener is spawned detached and reaped on a background thread, so a slow or missing opener can never block the callback server or fail the login.
- Prints `Opening in your browser...` only when an opener actually spawned; the existing URL output is unchanged either way (tools and wrappers parse it).
- Covers both the proxy-aware flow (`login_with_proxy_support`) and the `yup-oauth2` `InstalledFlowDelegate`.
- Refuses to pass unsafe values to an opener: non-`https` schemes, control/whitespace/dangerous-Unicode characters, quotes, backslashes, and shell metacharacters — addressing the Gemini review feedback on #875. `explorer` rather than `rundll32` on Windows addresses the EDR concern raised there. No new dependency.

Two small riders needed for a green CI run, called out so they don't surprise anyone:

- `helpers/script.rs`: clippy 1.97 (current stable) rejects a nested `if` inside a `match` on unmodified `main`, so `cargo clippy --workspace -- -D warnings` fails before this PR changes anything. Collapsed into a guarded match arm, behavior-preserving and covered by the existing tests.
- `auth.rs` tests: `test_load_credentials_encrypted_file` set `GOOGLE_WORKSPACE_CLI_CONFIG_DIR` with a bare `set_var` and never restored it, leaking a dropped tempdir path into later tests — `config_dir_returns_gws_subdir` failed roughly 1 in 6 local runs on unmodified `main`. Now uses the test module's own `EnvVarGuard`; 10 consecutive clean runs after.

**Dry Run Output:**
```
Not applicable — this changes the OAuth login flow, not an API request body.
```

## Test evidence

```text
$ cargo fmt --all -- --check          # exit 0
$ cargo clippy --workspace -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.22s
$ cargo test --workspace
    799 passed; 0 failed (repeated x10 for the flake fix: 10/10 clean)
```

New unit tests cover opener selection (`$BROWSER` precedence, per-OS defaults, unknown platform) and URL validation (accepts https OAuth URLs; rejects whitespace, control characters, RTL-override/zero-width Unicode, quotes, backslashes, and shell metacharacters).

## Checklist:

- [x] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [x] I have run `cargo fmt --all` to format the code perfectly.
- [x] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.
