### PR TITLE
fix(auth): preserve isolated credentials on decryption failure

### DIFF
--- a/.changeset/preserve-undecryptable-credentials.md
+++ b/.changeset/preserve-undecryptable-credentials.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Preserve encrypted credentials and token caches when credential decryption fails, stop instead of silently falling through to another identity, and default isolated config directories to profile-local key storage.

--- a/crates/google-workspace-cli/src/auth.rs
+++ b/crates/google-workspace-cli/src/auth.rs
@@ -358,33 +358,12 @@ async fn load_credentials_inner(
                 return parse_credential_file(enc_path, &json_str).await;
             }
             Err(e) => {
-                // Decryption failed — the encryption key likely changed (e.g. after
-                // an upgrade that migrated keys between keyring and file storage).
-                // Remove the stale file so the next `gws auth login` starts fresh,
-                // and fall through to other credential sources (plaintext, ADC).
-                eprintln!(
-                    "Warning: removing undecryptable credentials file ({}): {e:#}",
-                    enc_path.display()
-                );
-                if let Err(err) = tokio::fs::remove_file(enc_path).await {
-                    eprintln!(
-                        "Warning: failed to remove stale credentials file '{}': {err}",
+                return Err(e).with_context(|| {
+                    format!(
+                        "Failed to decrypt encrypted credentials at {}; file and token caches were preserved",
                         enc_path.display()
-                    );
-                }
-                // Also remove stale token caches that used the old key.
-                for cache_file in ["token_cache.json", "sa_token_cache.json"] {
-                    let path = enc_path.with_file_name(cache_file);
-                    if let Err(err) = tokio::fs::remove_file(&path).await {
-                        if err.kind() != std::io::ErrorKind::NotFound {
-                            eprintln!(
-                                "Warning: failed to remove stale token cache '{}': {err}",
-                                path.display()
-                            );
-                        }
-                    }
-                }
-                // Fall through to remaining credential sources below.
+                    )
+                });
             }
         }
     }
@@ -825,18 +804,26 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn test_load_credentials_corrupt_encrypted_file_is_removed() {
-        // When credentials.enc cannot be decrypted, the file should be removed
-        // automatically and the function should fall through to other sources.
+    async fn test_load_credentials_corrupt_encrypted_file_is_preserved() {
+        // A decryption failure must fail closed without deleting credentials or
+        // token caches. The operator may still be able to recover the key/file.
         let tmp = tempfile::tempdir().unwrap();
         let _home_guard = EnvVarGuard::set("HOME", tmp.path());
         let _adc_guard = EnvVarGuard::remove("GOOGLE_APPLICATION_CREDENTIALS");
 
         let dir = tempfile::tempdir().unwrap();
         let enc_path = dir.path().join("credentials.enc");
+        let token_cache_path = dir.path().join("token_cache.json");
+        let sa_token_cache_path = dir.path().join("sa_token_cache.json");
 
         // Write garbage data that cannot be decrypted.
         tokio::fs::write(&enc_path, b"not-valid-encrypted-data-at-all-1234567890")
+            .await
+            .unwrap();
+        tokio::fs::write(&token_cache_path, b"token-cache-sentinel")
+            .await
+            .unwrap();
+        tokio::fs::write(&sa_token_cache_path, b"sa-token-cache-sentinel")
             .await
             .unwrap();
         assert!(enc_path.exists());
@@ -844,24 +831,31 @@ mod tests {
         let result =
             load_credentials_inner(None, &enc_path, &PathBuf::from("/does/not/exist")).await;
 
-        // Should fall through to "No credentials found" (not a decryption error).
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(
-            msg.contains("No credentials found"),
-            "Should fall through to final error, got: {msg}"
+            msg.contains("Failed to decrypt encrypted credentials"),
+            "Should report the decryption failure, got: {msg}"
         );
         assert!(
-            !enc_path.exists(),
-            "Stale credentials.enc must be removed after decryption failure"
+            enc_path.exists(),
+            "credentials.enc must be preserved after decryption failure"
+        );
+        assert_eq!(
+            tokio::fs::read(&token_cache_path).await.unwrap(),
+            b"token-cache-sentinel"
+        );
+        assert_eq!(
+            tokio::fs::read(&sa_token_cache_path).await.unwrap(),
+            b"sa-token-cache-sentinel"
         );
     }
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn test_load_credentials_corrupt_encrypted_falls_through_to_plaintext() {
-        // When credentials.enc is corrupt but a valid plaintext file exists,
-        // the function should fall through and use the plaintext credentials.
+    async fn test_load_credentials_corrupt_encrypted_does_not_fall_through_to_plaintext() {
+        // Falling through could silently authenticate as a different principal
+        // or with different scopes, so an encrypted-credential failure is final.
         let dir = tempfile::tempdir().unwrap();
         let enc_path = dir.path().join("credentials.enc");
         let plain_path = dir.path().join("credentials.json");
@@ -880,20 +874,20 @@ mod tests {
         }"#;
         tokio::fs::write(&plain_path, plain_json).await.unwrap();
 
-        let res = load_credentials_inner(None, &enc_path, &plain_path)
+        let err = load_credentials_inner(None, &enc_path, &plain_path)
             .await
-            .unwrap();
+            .unwrap_err();
 
-        match res {
-            Credential::AuthorizedUser(secret) => {
-                assert_eq!(
-                    secret.client_id, "fallback_id",
-                    "Should fall through to plaintext credentials"
-                );
-            }
-            _ => panic!("Expected AuthorizedUser from plaintext fallback"),
-        }
-        assert!(!enc_path.exists(), "Stale credentials.enc must be removed");
+        assert!(
+            err.to_string()
+                .contains("Failed to decrypt encrypted credentials"),
+            "Should report the encrypted credential failure, got: {err:#}"
+        );
+        assert!(enc_path.exists(), "credentials.enc must be preserved");
+        assert!(
+            plain_path.exists(),
+            "plaintext fallback must remain untouched"
+        );
     }
 
     #[tokio::test]

--- a/crates/google-workspace-cli/src/credential_store.rs
+++ b/crates/google-workspace-cli/src/credential_store.rs
@@ -148,8 +148,12 @@ impl KeyringProvider for OsKeyring {
 /// Which backend to use for encryption key storage.
 ///
 /// Controlled by `GOOGLE_WORKSPACE_CLI_KEYRING_BACKEND`:
-/// - `"keyring"` (default): Use OS keyring, fall back to `.encryption_key` file
+/// - `"keyring"`: Use OS keyring, fall back to `.encryption_key` file
 /// - `"file"`: Use `.encryption_key` file only (for Docker/CI/headless)
+///
+/// With no explicit backend, the default config directory uses the OS keyring,
+/// while an isolated `GOOGLE_WORKSPACE_CLI_CONFIG_DIR` uses its profile-local
+/// key file. This prevents custom profiles from sharing one OS-keyring entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum KeyringBackend {
     Keyring,
@@ -158,18 +162,29 @@ enum KeyringBackend {
 
 impl KeyringBackend {
     fn from_env() -> Self {
-        let raw = std::env::var("GOOGLE_WORKSPACE_CLI_KEYRING_BACKEND").unwrap_or_default();
-        let lower = raw.to_lowercase();
+        let raw = std::env::var("GOOGLE_WORKSPACE_CLI_KEYRING_BACKEND").ok();
+        let custom_config_dir = std::env::var_os("GOOGLE_WORKSPACE_CLI_CONFIG_DIR").is_some();
+        Self::from_setting(raw.as_deref(), custom_config_dir)
+    }
+
+    fn from_setting(raw: Option<&str>, custom_config_dir: bool) -> Self {
+        let default = if custom_config_dir {
+            KeyringBackend::File
+        } else {
+            KeyringBackend::Keyring
+        };
+        let lower = raw.unwrap_or_default().to_lowercase();
         match lower.as_str() {
             "file" => KeyringBackend::File,
-            "keyring" | "" => KeyringBackend::Keyring,
+            "keyring" => KeyringBackend::Keyring,
+            "" => default,
             other => {
-                // Item 1: warn on unrecognized values
                 eprintln!(
                     "Warning: unknown GOOGLE_WORKSPACE_CLI_KEYRING_BACKEND=\"{other}\", \
-                     defaulting to \"keyring\". Valid values: \"keyring\", \"file\"."
+                     defaulting to \"{}\". Valid values: \"keyring\", \"file\".",
+                    default.as_str()
                 );
-                KeyringBackend::Keyring
+                default
             }
         }
     }
@@ -811,8 +826,26 @@ mod tests {
 
     #[test]
     fn backend_default_is_keyring() {
-        // from_env reads the env; default (empty/unset) → Keyring
-        assert_eq!(KeyringBackend::from_env(), KeyringBackend::Keyring);
+        assert_eq!(
+            KeyringBackend::from_setting(None, false),
+            KeyringBackend::Keyring
+        );
+    }
+
+    #[test]
+    fn custom_config_dir_defaults_to_file_backend() {
+        assert_eq!(
+            KeyringBackend::from_setting(None, true),
+            KeyringBackend::File
+        );
+    }
+
+    #[test]
+    fn explicit_keyring_overrides_custom_config_default() {
+        assert_eq!(
+            KeyringBackend::from_setting(Some("keyring"), true),
+            KeyringBackend::Keyring
+        );
     }
 
     // ---- read_key_file tests ----


### PR DESCRIPTION
## Description

Preserve isolated encrypted credentials and token caches when decryption fails, fail closed instead of silently authenticating with another credential source, and default custom config directories to profile-local file key storage unless the backend is explicitly overridden.

Source implementation commit: `d594aec746955373976619876e95f237872ab0db`.
Delivery commit: `27619dc7ccbf46f7cdf85d6c54c5bcc3a1ad42f2` (cherry-picked with traceability).

**Dry Run Output:**
Not applicable; this is an authentication and credential-storage fix with no API request or helper command change.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p google-workspace-cli --bin gws auth::tests` — 23 passed
- [x] `cargo test -p google-workspace-cli --bin gws credential_store::tests` — 28 passed
- [x] `cargo test -p google-workspace-cli` — 703 passed
- [x] `cargo clippy -p google-workspace-cli --bin gws -- -D warnings`
- [x] `cargo build -p google-workspace-cli`
- [x] `git diff --check`
- [x] pre-push hook — `cargo check`, `google-workspace` 82 tests, CLI 703 tests
- [x] Changeset added: `.changeset/preserve-undecryptable-credentials.md`

The final branch is based on `origin/main` `a3768d0e82ad83cca2da97724e46bea4ff0e6dbd` and changes only the changeset, `auth.rs`, and `credential_store.rs`. No Google Workspace APIs, credentials, scopes, users, Sheet, or email were touched; human review and merge remain pending.
