### PR TITLE
fix(gmail): preserve rich message bodies in read

### DIFF
--- a/.changeset/fix-gmail-read-body-extraction.md
+++ b/.changeset/fix-gmail-read-body-extraction.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Preserve complete, structured Gmail message content when `+read` converts HTML bodies to text.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,6 +929,7 @@ dependencies = [
  "futures-util",
  "google-workspace",
  "hostname",
+ "html2text",
  "iana-time-zone",
  "keyring",
  "mail-builder",
@@ -1014,6 +1015,28 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-link",
+]
+
+[[package]]
+name = "html2text"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c97eea9d3e6524d8d2a4643ce0e3135500c4c7ca1d02393a485f871bef69d8"
+dependencies = [
+ "html5ever",
+ "tendril",
+ "thiserror 2.0.18",
+ "unicode-width",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever",
 ]
 
 [[package]]
@@ -1488,6 +1511,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1552,6 +1586,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -1751,13 +1791,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -1771,12 +1831,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.11.3",
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
@@ -1799,6 +1869,15 @@ name = "phf_shared"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -1850,6 +1929,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -2553,6 +2638,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,6 +2750,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
+dependencies = [
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "terminfo"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2649,7 +2767,7 @@ dependencies = [
  "fnv",
  "nom",
  "phf 0.11.3",
- "phf_codegen",
+ "phf_codegen 0.11.3",
 ]
 
 [[package]]
@@ -3319,6 +3437,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/crates/google-workspace-cli/Cargo.toml
+++ b/crates/google-workspace-cli/Cargo.toml
@@ -38,6 +38,7 @@ clap = { version = "4", features = ["derive", "string"] }
 dirs = "5"
 dotenvy = "0.15"
 hostname = "0.4"
+html2text = "0.17.1"
 reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls-native-roots", "socks"], default-features = false }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/crates/google-workspace-cli/src/helpers/gmail/mod.rs
+++ b/crates/google-workspace-cli/src/helpers/gmail/mod.rs
@@ -38,6 +38,7 @@ pub(super) use mail_builder::headers::address::Address as MbAddress;
 pub(super) use serde::Serialize;
 pub(super) use serde_json::{json, Value};
 use std::future::Future;
+use std::io::Read;
 use std::pin::Pin;
 
 pub struct GmailHelper;
@@ -176,10 +177,10 @@ impl OriginalPart {
 /// A parsed Gmail message fetched via the API, used as context for reply/forward.
 ///
 /// `from` is always populated — `parse_original_message` returns an error when
-/// `From` is missing. `body_text` always has a value — it falls back to the
-/// message snippet when no `text/plain` MIME part is found. Semantically optional
-/// fields (`cc`, `reply_to`, `date`, `body_html`) use `Option` so the compiler
-/// enforces absence checks.
+/// `From` is missing. `body_text` always has a value — HTML-only messages are
+/// rendered as readable text, with the message snippet as a final fallback.
+/// Semantically optional fields (`cc`, `reply_to`, `date`, `body_html`) use
+/// `Option` so the compiler enforces absence checks.
 #[derive(Default, Serialize)]
 pub(super) struct OriginalMessage {
     pub thread_id: Option<String>,
@@ -334,7 +335,12 @@ fn parse_original_message(msg: &Value) -> Result<OriginalMessage, GwsError> {
         .map(extract_payload_contents)
         .unwrap_or_default();
 
-    let body_text = extracted_text.unwrap_or(snippet);
+    let converted_html = body_html.as_deref().and_then(convert_html_to_readable_text);
+    let body_text = select_readable_body(
+        extracted_text.as_deref(),
+        converted_html.as_deref(),
+        &snippet,
+    );
 
     // Parse references: split on whitespace and strip any angle brackets, producing bare IDs
     let references = parsed_headers
@@ -362,6 +368,55 @@ fn parse_original_message(msg: &Value) -> Result<OriginalMessage, GwsError> {
         body_html,
         parts: original_parts,
     })
+}
+
+/// Convert HTML to readable plain text without dropping link targets or document structure.
+/// A wide render width minimizes presentation-only wrapping while retaining block breaks.
+fn convert_html_to_readable_text(html: &str) -> Option<String> {
+    render_html_to_readable_text(html.as_bytes())
+}
+
+fn render_html_to_readable_text(reader: impl Read) -> Option<String> {
+    match html2text::from_read(reader, 120) {
+        Ok(text) => Some(text.trim().to_string()).filter(|text| !text.is_empty()),
+        Err(e) => {
+            eprintln!(
+                "Warning: text/html body could not be rendered as text: {}",
+                sanitize_for_terminal(&e.to_string())
+            );
+            None
+        }
+    }
+}
+
+/// Prefer a converted HTML alternative only when it contains substantially more readable
+/// content than the supplied plain-text alternative. This avoids replacing a good plain part
+/// for minor formatting differences while recovering messages whose plain part is only a stub.
+fn select_readable_body(
+    plain_text: Option<&str>,
+    converted_html: Option<&str>,
+    snippet: &str,
+) -> String {
+    let plain_text = plain_text.filter(|text| !text.trim().is_empty());
+    let converted_html = converted_html.filter(|text| !text.trim().is_empty());
+
+    match (plain_text, converted_html) {
+        (None, Some(html)) => html.to_string(),
+        (Some(plain), Some(html)) if html_is_substantially_richer(plain, html) => html.to_string(),
+        (Some(plain), _) => plain.to_string(),
+        (None, None) => snippet.to_string(),
+    }
+}
+
+fn html_is_substantially_richer(plain_text: &str, converted_html: &str) -> bool {
+    const MIN_EXTRA_CHARS: usize = 80;
+    const MIN_RATIO: usize = 2;
+
+    let plain_chars = plain_text.trim().chars().count();
+    let html_chars = converted_html.trim().chars().count();
+
+    html_chars >= plain_chars.saturating_mul(MIN_RATIO)
+        && html_chars.saturating_sub(plain_chars) >= MIN_EXTRA_CHARS
 }
 
 pub(super) async fn fetch_message_metadata(
@@ -2225,8 +2280,8 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_original_message_snippet_fallback() {
-        // When only text/html is present (no text/plain), body_text falls back to snippet
+    fn test_parse_original_message_html_fallback() {
+        // When only text/html is present, body_text is rendered from the complete HTML body.
         let msg = json!({
             "threadId": "t1",
             "snippet": "Snippet fallback text",
@@ -2240,7 +2295,7 @@ mod tests {
             }
         });
         let original = parse_original_message(&msg).unwrap();
-        assert_eq!(original.body_text, "Snippet fallback text");
+        assert_eq!(original.body_text, "HTML only");
         assert_eq!(original.body_html.unwrap(), "<p>HTML only</p>");
     }
 
@@ -2423,7 +2478,7 @@ mod tests {
             original.references,
             vec!["ref-1@example.com", "ref-2@example.com"]
         );
-        assert_eq!(original.body_text, "Snippet fallback");
+        assert_eq!(original.body_text, "HTML only");
         assert_eq!(original.body_html.as_deref(), Some("<p>HTML only</p>"));
     }
 
@@ -2458,6 +2513,193 @@ mod tests {
 
         assert_eq!(original.body_text, "Plain text body");
         assert_eq!(original.body_html.as_deref(), Some("<p>Rich HTML body</p>"));
+    }
+
+    fn synthetic_message_with_payload(snippet: &str, mut payload: Value) -> Value {
+        payload.as_object_mut().unwrap().insert(
+            "headers".to_string(),
+            json!([
+                { "name": "From", "value": "sender@example.com" },
+                { "name": "To", "value": "recipient@example.com" },
+                { "name": "Message-ID", "value": "<synthetic@example.com>" }
+            ]),
+        );
+
+        json!({
+            "threadId": "synthetic-thread",
+            "snippet": snippet,
+            "payload": payload,
+        })
+    }
+
+    #[test]
+    fn test_read_prefers_substantially_richer_html_alternative() {
+        let payload = json!({
+            "mimeType": "multipart/alternative",
+            "parts": [
+                {
+                    "mimeType": "text/plain",
+                    "body": { "data": URL_SAFE.encode("View this message online.") }
+                },
+                {
+                    "mimeType": "text/html",
+                    "body": {
+                        "data": URL_SAFE.encode(
+                            "<p>Your synthetic quarterly report is ready.</p>\
+                             <p>Revenue increased across every region, and the detailed \
+                             analysis contains the unique marker RICH-ALTERNATIVE-CONTENT.</p>"
+                        )
+                    }
+                }
+            ]
+        });
+        let msg = synthetic_message_with_payload("unused snippet", payload);
+
+        let original = parse_original_message(&msg).unwrap();
+
+        assert!(original.body_text.contains("RICH-ALTERNATIVE-CONTENT"));
+    }
+
+    #[test]
+    fn test_read_uses_html_alternative_when_plain_part_is_empty() {
+        let payload = json!({
+            "mimeType": "multipart/alternative",
+            "parts": [
+                {
+                    "mimeType": "text/plain",
+                    "body": { "data": URL_SAFE.encode("") }
+                },
+                {
+                    "mimeType": "text/html",
+                    "body": { "data": URL_SAFE.encode("<p>Complete synthetic HTML body</p>") }
+                }
+            ]
+        });
+        let msg = synthetic_message_with_payload("incomplete snippet", payload);
+
+        let original = parse_original_message(&msg).unwrap();
+
+        assert_eq!(original.body_text, "Complete synthetic HTML body");
+    }
+
+    #[test]
+    fn test_read_keeps_comparable_plain_text_alternative() {
+        let payload = json!({
+            "mimeType": "multipart/alternative",
+            "parts": [
+                {
+                    "mimeType": "text/plain",
+                    "body": { "data": URL_SAFE.encode("Preferred plain wording") }
+                },
+                {
+                    "mimeType": "text/html",
+                    "body": { "data": URL_SAFE.encode("<p>Similar HTML wording</p>") }
+                }
+            ]
+        });
+        let msg = synthetic_message_with_payload("unused snippet", payload);
+
+        let original = parse_original_message(&msg).unwrap();
+
+        assert_eq!(original.body_text, "Preferred plain wording");
+    }
+
+    #[test]
+    fn test_html_conversion_empty_and_read_error_fall_back() {
+        struct FailingReader;
+
+        impl std::io::Read for FailingReader {
+            fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("synthetic read failure"))
+            }
+        }
+
+        assert!(convert_html_to_readable_text("<p></p>").is_none());
+        assert!(render_html_to_readable_text(FailingReader).is_none());
+    }
+
+    #[test]
+    fn test_read_html_only_body_is_not_replaced_by_truncated_snippet() {
+        let long_body = format!(
+            "<p>{}</p><p>NON-TRUNCATED-TAIL</p>",
+            "Synthetic long-form message content. ".repeat(120)
+        );
+        let payload = json!({
+            "mimeType": "text/html",
+            "body": { "data": URL_SAFE.encode(&long_body) }
+        });
+        let msg = synthetic_message_with_payload(
+            "Synthetic long-form message content. Synthetic long-form message con",
+            payload,
+        );
+
+        let original = parse_original_message(&msg).unwrap();
+
+        assert!(original.body_text.len() > 3_200);
+        assert!(original.body_text.contains("NON-TRUNCATED-TAIL"));
+    }
+
+    #[test]
+    fn test_read_html_only_body_preserves_anchor_href() {
+        let payload = json!({
+            "mimeType": "text/html",
+            "body": {
+                "data": URL_SAFE.encode(
+                    "<p><a href=\"https://example.test/invitations/synthetic-token\">\
+                     Accept invitation</a></p>"
+                )
+            }
+        });
+        let msg = synthetic_message_with_payload("Accept invitation", payload);
+
+        let original = parse_original_message(&msg).unwrap();
+
+        assert!(original
+            .body_text
+            .contains("https://example.test/invitations/synthetic-token"));
+    }
+
+    #[test]
+    fn test_read_html_only_body_decodes_entities() {
+        let payload = json!({
+            "mimeType": "text/html",
+            "body": {
+                "data": URL_SAFE.encode("<p>Tom &amp; Jerry&#39;s synthetic report</p>")
+            }
+        });
+        let msg = synthetic_message_with_payload("Tom &amp; Jerry&#39;s synthetic report", payload);
+
+        let original = parse_original_message(&msg).unwrap();
+
+        assert!(original
+            .body_text
+            .contains("Tom & Jerry's synthetic report"));
+    }
+
+    #[test]
+    fn test_read_html_only_body_preserves_block_line_breaks() {
+        let payload = json!({
+            "mimeType": "text/html",
+            "body": {
+                "data": URL_SAFE.encode(
+                    "<p>First synthetic paragraph</p><div>Second synthetic block</div>"
+                )
+            }
+        });
+        let msg = synthetic_message_with_payload(
+            "First synthetic paragraphSecond synthetic block",
+            payload,
+        );
+
+        let original = parse_original_message(&msg).unwrap();
+        let first_end = original
+            .body_text
+            .find("First synthetic paragraph")
+            .unwrap()
+            + "First synthetic paragraph".len();
+        let second_start = original.body_text.find("Second synthetic block").unwrap();
+
+        assert!(original.body_text[first_end..second_start].contains('\n'));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes #889.

Gmail `+read` currently falls back to the truncated snippet for HTML-only messages and can prefer a short or empty `text/plain` alternative over substantially richer HTML. Naive tag stripping also loses link targets, entity decoding, and block structure.

This change:

- renders HTML bodies to readable text with `html2text`, retaining links and document structure
- prefers rendered HTML only when it is substantially richer than a non-empty plain-text alternative
- keeps comparable valid plain text and uses the Gmail snippet only when neither body yields readable content
- adds a patch changeset and locks the new dependency

All fixtures are synthetic; no Gmail account, credentials, or real messages were used.

## Validation

The five initial regressions all failed on pristine `a3768d0`:

```text
0 passed; 5 failed; 701 filtered out
```

They cover richer multipart selection, non-truncation, anchor `href` preservation, HTML entity decoding, and block line breaks. The final suite also covers empty and comparable plain-text alternatives.

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p google-workspace-cli test_read_` — 7 passed
- [x] `cargo test -p google-workspace-cli helpers::gmail::` — 242 passed
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] serialized workspace suite — CLI 707 passed with two unrelated, pre-existing Windows ADC tests excluded
- [x] Changeset included

The two excluded ADC tests mutate `HOME` while `dirs::home_dir()` reads `USERPROFILE` on Windows; they are outside the Gmail helper and unchanged by this commit.
