### PR TITLE
fix(auth): trim OAuth credentials during setup

### DIFF
--- a/.changeset/trim-oauth-credentials.md
+++ b/.changeset/trim-oauth-credentials.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Trim pasted OAuth client IDs and secrets during interactive setup so invisible surrounding whitespace does not cause authentication failures.

--- a/crates/google-workspace-cli/src/setup.rs
+++ b/crates/google-workspace-cli/src/setup.rs
@@ -1473,6 +1473,16 @@ fn manual_oauth_instructions(project_id: &str) -> String {
     )
 }
 
+fn normalize_oauth_credential(value: String, field_name: &str) -> Result<String, GwsError> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(GwsError::Validation(format!(
+            "{field_name} cannot be empty"
+        )));
+    }
+    Ok(value)
+}
+
 /// Stage 5: Configure OAuth consent screen and collect client credentials.
 async fn stage_configure_oauth(ctx: &mut SetupContext) -> Result<SetupStage, GwsError> {
     ctx.wiz(4, StepStatus::InProgress("Configuring...".into()));
@@ -1521,7 +1531,7 @@ async fn stage_configure_oauth(ctx: &mut SetupContext) -> Result<SetupStage, Gws
             .map_err(|e| GwsError::Validation(format!("TUI error: {e}")))?;
 
         let csec_res = match &cid_res {
-            crate::setup_tui::InputResult::Confirmed(v) if !v.is_empty() => w
+            crate::setup_tui::InputResult::Confirmed(v) if !v.trim().is_empty() => w
                 .show_input(
                     "Enter OAuth Client Secret",
                     "Paste the Client Secret from Google Cloud Console",
@@ -1541,11 +1551,7 @@ async fn stage_configure_oauth(ctx: &mut SetupContext) -> Result<SetupStage, Gws
 
     ctx.client_id = match cid_result {
         crate::setup_tui::InputResult::Confirmed(v) => {
-            if v.is_empty() {
-                ctx.finish_wizard();
-                return Err(GwsError::Validation("Client ID cannot be empty".into()));
-            }
-            v
+            normalize_oauth_credential(v, "Client ID").inspect_err(|_| ctx.finish_wizard())?
         }
         crate::setup_tui::InputResult::GoBack => {
             return Ok(SetupStage::EnableApis);
@@ -1558,11 +1564,7 @@ async fn stage_configure_oauth(ctx: &mut SetupContext) -> Result<SetupStage, Gws
 
     ctx.client_secret = match csecret_result {
         crate::setup_tui::InputResult::Confirmed(v) => {
-            if v.is_empty() {
-                ctx.finish_wizard();
-                return Err(GwsError::Validation("Client Secret cannot be empty".into()));
-            }
-            v
+            normalize_oauth_credential(v, "Client Secret").inspect_err(|_| ctx.finish_wizard())?
         }
         crate::setup_tui::InputResult::GoBack => {
             return Ok(SetupStage::EnableApis);
@@ -1928,6 +1930,31 @@ mod tests {
     #[test]
     fn test_should_not_offer_login_prompt_dry_run() {
         assert!(!should_offer_login_prompt(true, true, false, true));
+    }
+
+    #[test]
+    fn test_normalize_oauth_credential_trims_surrounding_whitespace() {
+        assert_eq!(
+            normalize_oauth_credential("  client-id\n".into(), "Client ID").unwrap(),
+            "client-id"
+        );
+        assert_eq!(
+            normalize_oauth_credential("\tclient secret  ".into(), "Client Secret").unwrap(),
+            "client secret"
+        );
+    }
+
+    #[test]
+    fn test_normalize_oauth_credential_rejects_whitespace_only_input() {
+        let client_id_error = normalize_oauth_credential(" \t\n".into(), "Client ID").unwrap_err();
+        assert_eq!(client_id_error.to_string(), "Client ID cannot be empty");
+
+        let client_secret_error =
+            normalize_oauth_credential("\n  ".into(), "Client Secret").unwrap_err();
+        assert_eq!(
+            client_secret_error.to_string(),
+            "Client Secret cannot be empty"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Closes #882.

Interactive OAuth setup now trims leading and trailing whitespace from pasted Client IDs and client secrets before validation and persistence. Whitespace-only values are rejected as empty, while characters inside a credential are preserved.

This prevents invisible spaces or newlines copied from Google Cloud Console from producing an invalid_client response during login.

**Dry Run Output:** Not applicable; this changes interactive credential input and does not create a Discovery API request.

## Validation

- cargo fmt --all -- --check
- cargo test --workspace -- --test-threads=1 (785 tests passed)
- cargo clippy -- -D warnings -A clippy::collapsible_match
- cargo clippy -- -D warnings is currently blocked on unchanged main-branch code at helpers/script.rs:173 by the Rust 1.97 collapsible_match lint

## Checklist:

- [x] My code follows the AGENTS.md guidelines (no generated google-* crates).
- [x] I have run cargo fmt --all to format the code perfectly.
- [ ] I have run cargo clippy -- -D warnings and resolved all warnings. See the documented pre-existing main-branch warning above; the changed code is clean.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file to document my changes.