### PR TITLE
fix(auth): refresh cached tokens without expiry

### DIFF
--- a/.changeset/refresh-tokens-without-expiry.md
+++ b/.changeset/refresh-tokens-without-expiry.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Refresh cached OAuth access tokens whose expiration time is missing instead of reusing them indefinitely.

--- a/crates/google-workspace-cli/src/token_storage.rs
+++ b/crates/google-workspace-cli/src/token_storage.rs
@@ -149,7 +149,12 @@ impl TokenStorage for EncryptedTokenStorage {
         if let Some(map) = map_lock.as_ref() {
             let key = Self::cache_key(scopes);
             if let Some(token) = map.get(&key) {
-                return Some(token.clone());
+                // yup-oauth2 treats a missing expiry as "never expires". Google access tokens
+                // are short-lived, so reusing such an entry can cause permanent 401 responses.
+                // Treat it as a cache miss and let the authenticator fetch a fresh token.
+                if token.expires_at.is_some() {
+                    return Some(token.clone());
+                }
             }
         }
 
@@ -171,5 +176,41 @@ mod tests {
 
         let cache_lock = storage.cache.lock().await;
         assert!(cache_lock.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_ignores_cached_token_without_expiry() {
+        let storage = EncryptedTokenStorage::new(PathBuf::from("/unused/token.json"));
+        let scopes = ["scope-a", "scope-b"];
+        let token = TokenInfo {
+            access_token: Some("stale-access-token".into()),
+            refresh_token: Some("refresh-token".into()),
+            expires_at: None,
+            id_token: None,
+        };
+
+        *storage.cache.lock().await = Some(HashMap::from([(
+            EncryptedTokenStorage::cache_key(&scopes),
+            token,
+        )]));
+
+        assert!(storage.get(&scopes).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_returns_cached_token_with_known_expiry() {
+        let storage = EncryptedTokenStorage::new(PathBuf::from("/unused/token.json"));
+        let scopes = ["scope-a"];
+        let token: TokenInfo = serde_json::from_str(
+            r#"{"access_token":"access-token","refresh_token":"refresh-token","expires_at":[2026,43,19,44,15,0,0,0,0],"id_token":null}"#,
+        )
+        .unwrap();
+
+        *storage.cache.lock().await = Some(HashMap::from([(
+            EncryptedTokenStorage::cache_key(&scopes),
+            token.clone(),
+        )]));
+
+        assert_eq!(storage.get(&scopes).await, Some(token));
     }
 }


### PR DESCRIPTION
## Description

Closes #904.

Encrypted token storage now treats a cached token with no expiration time as a cache miss. This lets the OAuth authenticator obtain a fresh token instead of reusing the same access token indefinitely and producing permanent per-scope 401 responses.

Cached tokens with a known expiration time continue through the existing yup-oauth2 freshness and refresh logic unchanged.

**Dry Run Output:** Not applicable; this changes local OAuth token-cache behavior and does not create a Discovery API request.

## Validation

- cargo fmt --all -- --check
- cargo test -p google-workspace-cli token_storage::tests
- cargo test --workspace -- --test-threads=1 (785 tests passed)
- cargo clippy -- -D warnings -A clippy::collapsible_match
- cargo clippy -- -D warnings is currently blocked on unchanged main-branch code at helpers/script.rs:173 by the Rust 1.97 collapsible_match lint

## Checklist:

- [x] My code follows the AGENTS.md guidelines (no generated google-* crates).
- [x] I have run cargo fmt --all to format the code perfectly.
- [ ] I have run cargo clippy -- -D warnings and resolved all warnings. See the documented pre-existing main-branch warning above; the changed code is clean.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have provided a Changeset file to document my changes.