### PR TITLE
fix(gmail): preserve Cc recipients regardless of header casing

### DIFF
--- a/.changeset/fix-gmail-cc-header-case.md
+++ b/.changeset/fix-gmail-cc-header-case.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Preserve Gmail Cc recipients when the API returns a differently cased header name.

--- a/crates/google-workspace-cli/src/helpers/gmail/mod.rs
+++ b/crates/google-workspace-cli/src/helpers/gmail/mod.rs
@@ -262,7 +262,9 @@ fn parse_message_headers(headers: &[Value]) -> ParsedMessageHeaders {
             "From" => parsed.from = value.to_string(),
             "Reply-To" => append_address_list_header_value(&mut parsed.reply_to, value),
             "To" => append_address_list_header_value(&mut parsed.to, value),
-            "Cc" => append_address_list_header_value(&mut parsed.cc, value),
+            _ if name.eq_ignore_ascii_case("Cc") => {
+                append_address_list_header_value(&mut parsed.cc, value)
+            }
             "Subject" => parsed.subject = value.to_string(),
             "Date" => parsed.date = value.to_string(),
             "Message-ID" | "Message-Id" => parsed.message_id = value.to_string(),
@@ -2032,6 +2034,18 @@ mod tests {
         let raw = mb.write_to_string().unwrap();
         let to = extract_header(&raw, "To").unwrap();
         assert!(to.contains("alice@example.com"));
+    }
+
+    #[test]
+    fn test_parse_message_headers_preserves_cc_regardless_of_header_case() {
+        let headers = vec![
+            json!({"name": "CC", "value": "alice@example.com"}),
+            json!({"name": "cc", "value": "bob@example.com"}),
+        ];
+
+        let parsed = parse_message_headers(&headers);
+
+        assert_eq!(parsed.cc, "alice@example.com, bob@example.com");
     }
 
     #[test]


### PR DESCRIPTION
Fix Gmail +reply-all dropping Cc recipients when header casing differs

## Problem

Gmail header names are case-insensitive, but `+reply-all` only recognized the exact spelling `Cc`. Messages returned with `CC`, `cc`, or another casing were parsed without any Cc recipients, so the reply omitted people who were copied on the original message.

Minimal reproduction:

1. Reply-all to a message whose Gmail API payload contains a header such as `{ "name": "CC", "value": "alice@example.com" }`.
2. The current parser falls through to `_` and leaves `ParsedMessageHeaders.cc` empty.
3. The generated reply therefore does not include the original Cc recipient.

## Root cause

`parse_message_headers` used a case-sensitive string match for `"Cc"`. RFC 5322 header field names are case-insensitive, and Gmail can return equivalent casing variants.

## Changes

- Match the Cc header with `eq_ignore_ascii_case("Cc")` while preserving existing address-list concatenation and formatting.
- Add a focused regression test covering both `CC` and `cc` headers and asserting that both recipients are retained.
- Add the required patch changeset.

## Validation

- `cargo test -p google-workspace-cli helpers::gmail::tests -- --nocapture` (113 passed)
- `cargo test -p google-workspace-cli helpers::gmail::tests::test_parse_message_headers_preserves_cc_regardless_of_header_case -- --exact --nocapture` (1 passed)
- `cargo fmt --all -- --check` (passed)
- `cargo clippy -p google-workspace-cli -- -D warnings -A clippy::collapsible-match` (passed; the allow is for an existing unrelated warning in `helpers/script.rs`)
- `git diff --check` (passed)

Other header handling and normal truncation/error behavior are unchanged. This closes #911.
