### PR TITLE
docs(gmail): correct draft send command tip

### DIFF
--- a/.changeset/fix-gmail-draft-send-tip.md
+++ b/.changeset/fix-gmail-draft-send-tip.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Correct the Gmail draft send command shown by the `--draft` helper.

--- a/crates/google-workspace-cli/src/helpers/gmail/mod.rs
+++ b/crates/google-workspace-cli/src/helpers/gmail/mod.rs
@@ -1431,6 +1431,10 @@ fn build_send_metadata(thread_id: Option<&str>, draft: bool) -> Option<String> {
     }
 }
 
+fn draft_send_tip() -> &'static str {
+    "gws gmail users drafts send --params '{\"userId\":\"me\"}' --json '{\"id\":\"<draft-id>\"}'"
+}
+
 pub(super) async fn dispatch_raw_email(
     doc: &crate::discovery::RestDescription,
     matches: &ArgMatches,
@@ -1488,7 +1492,7 @@ pub(super) async fn dispatch_raw_email(
 
     if draft && !matches.get_flag("dry-run") {
         eprintln!("Tip: copy the draft \"id\" from the response above, then send with:");
-        eprintln!("  gws gmail users.drafts.send --body '{{\"id\":\"<draft-id>\"}}'");
+        eprintln!("  {}", draft_send_tip());
     }
 
     Ok(())
@@ -2358,6 +2362,14 @@ mod tests {
         let parsed: Value = serde_json::from_str(&metadata).unwrap();
         assert!(parsed["message"].is_object());
         assert!(parsed["message"].get("threadId").is_none());
+    }
+
+    #[test]
+    fn test_draft_send_tip_uses_valid_discovery_command_syntax() {
+        assert_eq!(
+            draft_send_tip(),
+            "gws gmail users drafts send --params '{\"userId\":\"me\"}' --json '{\"id\":\"<draft-id>\"}'"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Correct the Gmail `--draft` send command shown to users

## Problem

After `gws gmail +send --draft` (and the other Gmail helpers that share this path) succeeds, the printed tip tells users to run:

```text
gws gmail users.drafts.send --body '{"id":"<draft-id>"}'
```

That is not valid discovery command syntax: resources and methods are separate positional arguments, and request parameters/body use `--params` and `--json`. Copying the tip therefore results in a command that fails before sending the draft.

## Changes

- Centralize the displayed command in `draft_send_tip()`.
- Print the valid equivalent:

```text
gws gmail users drafts send --params '{"userId":"me"}' --json '{"id":"<draft-id>"}'
```

- Add a unit test asserting the exact command string.
- Add the required patch changeset.

## Validation

- `cargo test -p google-workspace-cli helpers::gmail::tests::test_draft_send_tip_uses_valid_discovery_command_syntax -- --exact --nocapture`: 1 passed.
- `cargo test -p google-workspace-cli helpers::gmail::tests -- --nocapture`: 113 passed.
- `cargo fmt --all -- --check`: passed.
- `cargo clippy -p google-workspace-cli -- -D warnings -A clippy::collapsible-match`: passed; the allow covers an existing unrelated warning in `helpers/script.rs`.
- `git diff --check`: passed.

This is a user-facing documentation/error-message correction only; the draft creation and send API calls are unchanged. Closes #914.
