### PR TITLE
fix(script): preserve unreserved script ID characters

### DIFF
--- a/.changeset/fix-script-id-path-encoding.md
+++ b/.changeset/fix-script-id-path-encoding.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": patch
+---
+
+Preserve RFC 3986 unreserved characters in Apps Script IDs used in URL paths.

--- a/crates/google-workspace-cli/src/executor.rs
+++ b/crates/google-workspace-cli/src/executor.rs
@@ -714,6 +714,10 @@ fn render_path_template(
             let encoded = if is_plus {
                 let validated = crate::validate::validate_resource_name(&val_str)?;
                 crate::validate::encode_path_preserving_slashes(validated)
+            } else if key == "scriptId" {
+                // Apps Script's :run endpoint rejects percent-encoded RFC 3986
+                // unreserved characters (`-`, `_`, `.`, `~`) in script IDs.
+                encode_script_id_path_segment(&val_str)
             } else {
                 crate::validate::encode_path_segment(&val_str)
             };
@@ -727,6 +731,14 @@ fn render_path_template(
 
     rendered.push_str(&path_template[cursor..]);
     Ok(rendered)
+}
+
+fn encode_script_id_path_segment(value: &str) -> String {
+    crate::validate::encode_path_segment(value)
+        .replace("%2D", "-")
+        .replace("%5F", "_")
+        .replace("%2E", ".")
+        .replace("%7E", "~")
 }
 
 /// Attempts to extract a GCP console enable URL from a Google API `accessNotConfigured`
@@ -1879,6 +1891,31 @@ mod tests {
         assert_eq!(
             url,
             "https://api.example.com/v1/literal%2D%7Bchild%7D%2Dvalue/ok"
+        );
+    }
+
+    #[test]
+    fn test_build_url_preserves_unreserved_script_id_characters() {
+        let doc = RestDescription {
+            base_url: Some("https://script.googleapis.com/".to_string()),
+            ..Default::default()
+        };
+        let method = RestMethod {
+            path: "v1/scripts/{scriptId}:run".to_string(),
+            flat_path: Some("v1/scripts/{scriptId}:run".to_string()),
+            ..Default::default()
+        };
+        let mut params = Map::new();
+        params.insert(
+            "scriptId".to_string(),
+            json!("1-ukYIb6_NbryM5UJXBwAMeY5GKtSBA05csXty3iY7DhO-P"),
+        );
+
+        let (url, _) = build_url(&doc, &method, &params, false).unwrap();
+
+        assert_eq!(
+            url,
+            "https://script.googleapis.com/v1/scripts/1-ukYIb6_NbryM5UJXBwAMeY5GKtSBA05csXty3iY7DhO-P:run"
         );
     }
 


### PR DESCRIPTION
Fix Apps Script run URLs by preserving unreserved script ID characters

## Problem and reproduction

`gws script scripts run` builds a path containing `{scriptId}`. The generic path encoder currently percent-encodes every non-alphanumeric character, including RFC 3986 unreserved characters such as `-` and `_`.

With this valid script ID:

```text
1-ukYIb8XjT9KQlsj6_NbryM5UJXBwAMeY5GKtSBA05csXty3iY7DhO-P
```

the generated URL contains `%2D` and `%5F`. Apps Script's `:run` endpoint rejects that spelling with 404 even though the unencoded ID is valid.

## Root cause

`render_path_template` always called `encode_path_segment`, whose stricter encoding also escapes unreserved characters. The `scriptId` path parameter needs RFC 3986 unreserved characters preserved.

## Changes

- Add a script ID-specific path encoding helper that retains `-`, `_`, `.`, and `~` while continuing to percent-encode reserved and unsafe characters.
- Use that helper only for `scriptId` template parameters; all other path parameters retain existing encoding behavior.
- Add a regression test asserting the exact Apps Script `v1/scripts/{scriptId}:run` URL.
- Add the required patch changeset.

## Validation

- `cargo test -p google-workspace-cli executor::tests::test_build_url_preserves_unreserved_script_id_characters -- --exact --nocapture`: 1 passed.
- `cargo test -p google-workspace-cli executor::tests -- --nocapture`: 34 passed.
- `cargo fmt --all`: passed.
- `cargo clippy -p google-workspace-cli -- -D warnings -A clippy::collapsible-match`: passed; the allow covers an existing unrelated warning in `helpers/script.rs`.
- `git diff --check`: passed.

Reserved characters remain escaped and non-`scriptId` paths are unchanged. Closes #842.
